### PR TITLE
Avoid moving or removing .trash

### DIFF
--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/fs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",

--- a/packages/fs/src/Node.js
+++ b/packages/fs/src/Node.js
@@ -571,11 +571,11 @@ class Node {
 
   move(entry) {
     if (Node.isRoot(this)) {
-      throw new Error('You cannot modify the root node')
+      throw new Error('Root cannot be moved')
     }
 
     if (Node.isTrash(this)) {
-      throw new Error('You cannot modify the trash node')
+      throw new Error('Trash cannot be moved')
     }
 
     if (entry.id !== this.id) {

--- a/packages/fs/src/Node.js
+++ b/packages/fs/src/Node.js
@@ -571,7 +571,11 @@ class Node {
 
   move(entry) {
     if (Node.isRoot(this)) {
-      throw new Error('You cannot modify a root node')
+      throw new Error('You cannot modify the root node')
+    }
+
+    if (Node.isTrash(this)) {
+      throw new Error('You cannot modify the trash node')
     }
 
     if (entry.id !== this.id) {
@@ -626,6 +630,15 @@ class Node {
   }
 
   remove(version = []) {
+
+    if (Node.isRoot(this)) {
+      throw new Error('Root cannot be removed')
+    }
+
+    if (Node.isTrash(this)) {
+      throw new Error('Trash cannot be removed')
+    }
+
     if (this.parent) {
       if (!Array.isArray(version)) {
         version = [version]
@@ -660,12 +673,14 @@ class Node {
         this.parent.removeChild(this)
       }
       return result
-    } else {
-      throw new Error('Root cannot be removed')
     }
   }
 
   removeChild(child) {
+    if (Node.isTrash(child)) {
+      throw new Error('You cannot remove the trash node')
+    }
+
     delete this.children[child.id]
   }
 

--- a/packages/fs/test/Node.test.js
+++ b/packages/fs/test/Node.test.js
@@ -285,7 +285,7 @@ describe('#Node', function () {
         })
         assert.isFalse(true)
       } catch (e) {
-        assert.equal(e.message, 'You cannot modify the root node')
+        assert.equal(e.message, 'Root cannot be moved')
       }
 
     })
@@ -301,7 +301,7 @@ describe('#Node', function () {
         })
         assert.isFalse(true)
       } catch (e) {
-        assert.equal(e.message, 'You cannot modify the trash node')
+        assert.equal(e.message, 'Trash cannot be moved')
       }
 
     })

--- a/packages/fs/test/Node.test.js
+++ b/packages/fs/test/Node.test.js
@@ -285,7 +285,23 @@ describe('#Node', function () {
         })
         assert.isFalse(true)
       } catch (e) {
-        assert.equal(e.message, 'You cannot modify a root node')
+        assert.equal(e.message, 'You cannot modify the root node')
+      }
+
+    })
+
+    it('should throw trying to move trash', async function () {
+
+      let root = initARootNode()
+      let dir = initRandomNode(D, secrez)
+      let trash = Node.getTrash(root)
+      try {
+        trash.move({
+          parent: dir
+        })
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'You cannot modify the trash node')
       }
 
     })
@@ -356,6 +372,19 @@ describe('#Node', function () {
         assert.isFalse(true)
       } catch (e) {
         assert.equal(e.message, 'Root cannot be removed')
+      }
+
+    })
+
+    it('should throw trying to remove trash', async function () {
+
+      let root = initARootNode()
+
+      try {
+        Node.getTrash(root).remove()
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'Trash cannot be removed')
       }
 
     })

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf build",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@secrez/core": "^0.4.1",
-    "@secrez/fs": "^0.4.1",
+    "@secrez/fs": "^0.4.2",
     "chalk": "^3.0.0",
     "clipboardy": "^2.3.0",
     "command-line-args": "^5.1.1",


### PR DESCRIPTION
Add controls to avoid that the user can delete or move the trash node.