### PR TITLE
Add Yaml support for cards

### DIFF
--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -227,6 +227,14 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
 			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
 			"dev": true
+		},
+		"@babel/runtime": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+			"integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
 		},
 		"@babel/template": {
 			"version": "7.8.6",
@@ -579,6 +587,11 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
+		"case": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+			"integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="
+		},
 		"chai": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -817,6 +830,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"csv-parse": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.9.0.tgz",
+			"integrity": "sha512-SaFMvRWzobY9z0Nxg+q5pXvU2JY7p++icb1Bb/ZwGSLv058cLabhGg3YNpLPI2KALtZnoe/oNBCfWX9xgTkcaA=="
 		},
 		"d": {
 			"version": "1.0.1",
@@ -3021,6 +3039,11 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"regenerator-runtime": {
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -3730,6 +3753,14 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
+		},
+		"yaml": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+			"integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
+			"requires": {
+				"@babel/runtime": "^7.9.2"
+			}
 		},
 		"yargs": {
 			"version": "13.3.2",

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf build",
@@ -9,7 +9,7 @@
     "all-tests": "find test/** -name '*.test.js' | xargs ./node_modules/.bin/mocha -R spec",
     "test-only": "./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
-    "posttest": "nyc check-coverage --statements 95 --branches 75 --functions 95 --lines 95"
+    "posttest": "nyc check-coverage --statements 95 --branches 80 --functions 95 --lines 95"
   },
   "nyc": {
     "include": "src",
@@ -21,16 +21,19 @@
   "dependencies": {
     "@secrez/core": "^0.5.0",
     "@secrez/fs": "^0.5.0",
+    "case": "^1.6.3",
     "chalk": "^3.0.0",
     "clipboardy": "^2.3.0",
     "command-line-args": "^5.1.1",
+    "csv-parse": "^4.9.0",
     "external-editor": "^3.1.0",
     "fs-extra": "^8.1.0",
     "homedir": "^0.6.0",
     "inquirer": "^7.1.0",
     "inquirer-command-prompt": "^0.0.27",
     "lodash": "^4.17.15",
-    "tiny-cli-editor": "^0.1.1"
+    "tiny-cli-editor": "^0.1.1",
+    "yaml": "^1.9.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/packages/secrez/src/Command.js
+++ b/packages/secrez/src/Command.js
@@ -18,6 +18,11 @@ class Command {
   help() {
   }
 
+  showHelp() {
+    let command = this.constructor.name.toLowerCase()
+    this.prompt.commands.help.exec({command})
+  }
+
   setHelpAndCompletion() {
   }
 

--- a/packages/secrez/src/commands/Bash.js
+++ b/packages/secrez/src/commands/Bash.js
@@ -10,6 +10,11 @@ class Bash extends require('../Command') {
     this.noAutoComplete = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'command',
         alias: 'c',
         type: String,
@@ -34,6 +39,9 @@ class Bash extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       this.Logger.reset(await this.bash(options))
     } catch (e) {

--- a/packages/secrez/src/commands/Cd.js
+++ b/packages/secrez/src/commands/Cd.js
@@ -10,6 +10,11 @@ class Cd extends require('../Command') {
     this.cliConfig.completion.help.cd = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -49,6 +54,9 @@ class Cd extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       await this.cd(options)
     } catch (e) {

--- a/packages/secrez/src/commands/Create.js
+++ b/packages/secrez/src/commands/Create.js
@@ -12,6 +12,11 @@ class Create extends require('../Command') {
     this.cliConfig.completion.help.create = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'cleartext',
         alias: 'c',
         type: Boolean
@@ -33,7 +38,9 @@ class Create extends require('../Command') {
   }
 
   async exec(options = {}) {
-
+    if (options.help) {
+      return this.showHelp()
+    }
     let exitCode = Crypto.getRandomBase58String(2)
     try {
       /* istanbul ignore if  */

--- a/packages/secrez/src/commands/Export.js
+++ b/packages/secrez/src/commands/Export.js
@@ -14,6 +14,11 @@ class Export extends require('../Command') {
     this.cliConfig.completion.help.export = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -96,6 +101,9 @@ class Export extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       let name = await this.export(options)
       this.Logger.agua(options.clipboard ? 'Copied to clipboard:' : 'Exported file:')

--- a/packages/secrez/src/commands/Find.js
+++ b/packages/secrez/src/commands/Find.js
@@ -11,6 +11,11 @@ class Find extends require('../Command') {
     this.cliConfig.completion.help.find = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'name',
         alias: 'n',
         defaultOption: true,
@@ -99,6 +104,9 @@ class Find extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       let list = this.formatList(await this.find(options), options)
       if (list && list.length) {

--- a/packages/secrez/src/commands/Help.js
+++ b/packages/secrez/src/commands/Help.js
@@ -98,7 +98,7 @@ class Help extends require('../Command') {
         if (c) {
           this.Logger.log('black', spacer + e + ' '.repeat(max - e.length + 1), 'grey', c)
         } else {
-          this.Logger.log('black', spacer + e)
+          this.Logger.reset(spacer + e)
         }
       }
     }

--- a/packages/secrez/src/commands/Import.js
+++ b/packages/secrez/src/commands/Import.js
@@ -13,6 +13,11 @@ class Import extends require('../Command') {
     this.cliConfig.completion.help.import = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -111,6 +116,9 @@ class Import extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       let files = await this.import(options)
       if (files.length) {

--- a/packages/secrez/src/commands/Lcat.js
+++ b/packages/secrez/src/commands/Lcat.js
@@ -11,6 +11,11 @@ class Lcat extends require('../Command') {
     this.cliConfig.completion.help.lcat = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -45,6 +50,9 @@ class Lcat extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       let data = await this.lcat(options)
       this.Logger.reset(data)

--- a/packages/secrez/src/commands/Lcd.js
+++ b/packages/secrez/src/commands/Lcd.js
@@ -11,6 +11,11 @@ class Lcd extends require('../Command') {
     this.cliConfig.completion.help.lcd = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -50,6 +55,9 @@ class Lcd extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       options.all = true
       options.dironly = true

--- a/packages/secrez/src/commands/Lls.js
+++ b/packages/secrez/src/commands/Lls.js
@@ -10,6 +10,11 @@ class Lls extends require('../Command') {
     this.cliConfig.completion.help.lls = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -53,6 +58,9 @@ class Lls extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       options.returnIsDir = true
       let [isDir, list] = await this.externalFs.fileCompletion(options)

--- a/packages/secrez/src/commands/Lpwd.js
+++ b/packages/secrez/src/commands/Lpwd.js
@@ -3,6 +3,13 @@ class Lpwd extends require('../Command') {
   setHelpAndCompletion() {
     this.cliConfig.completion.lpwd = {}
     this.cliConfig.completion.help.lpwd = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      }
+    ]
   }
 
   help() {
@@ -20,7 +27,10 @@ class Lpwd extends require('../Command') {
     return this.cliConfig.localWorkingDir
   }
 
-  async exec() {
+  async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       this.Logger.reset(await this.lpwd())
     } catch (e) {

--- a/packages/secrez/src/commands/Ls.js
+++ b/packages/secrez/src/commands/Ls.js
@@ -8,6 +8,11 @@ class Ls extends require('../Command') {
     this.cliConfig.completion.help.ls = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -43,6 +48,9 @@ class Ls extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       let list = await this.ls(options)
       if (list) {

--- a/packages/secrez/src/commands/Mkdir.js
+++ b/packages/secrez/src/commands/Mkdir.js
@@ -10,6 +10,11 @@ class Mkdir extends require('../Command') {
     this.cliConfig.completion.help.mkdir = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -35,6 +40,9 @@ class Mkdir extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     if (!options.path) {
       this.Logger.red('Directory path not specified.')
     } else {

--- a/packages/secrez/src/commands/Mv.js
+++ b/packages/secrez/src/commands/Mv.js
@@ -11,6 +11,11 @@ class Mv extends require('../Command') {
     this.cliConfig.completion.help.mv = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -39,6 +44,9 @@ class Mv extends require('../Command') {
 
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       if (!options.path) {
         throw new Error('An origin path is required.')

--- a/packages/secrez/src/commands/Pwd.js
+++ b/packages/secrez/src/commands/Pwd.js
@@ -3,6 +3,13 @@ class Pwd extends require('../Command') {
   setHelpAndCompletion() {
     this.cliConfig.completion.pwd = {}
     this.cliConfig.completion.help.pwd = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      }
+    ]
   }
 
   help() {
@@ -18,7 +25,10 @@ class Pwd extends require('../Command') {
     return this.tree.workingNode.getPath()
   }
 
-  async exec() {
+  async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     try {
       this.Logger.reset(await this.pwd())
     } catch (e) {

--- a/packages/secrez/src/commands/Rm.js
+++ b/packages/secrez/src/commands/Rm.js
@@ -12,6 +12,11 @@ class Rm extends require('../Command') {
     this.cliConfig.completion.help.rm = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -49,6 +54,9 @@ class Rm extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     if (!options.path) {
       this.Logger.red('File path not specified.')
     } else if (/\?\*/.test(path.basename(options.path))) {

--- a/packages/secrez/src/commands/Touch.js
+++ b/packages/secrez/src/commands/Touch.js
@@ -10,6 +10,11 @@ class Touch extends require('../Command') {
     this.cliConfig.completion.help.touch = true
     this.optionDefinitions = [
       {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
         name: 'path',
         alias: 'p',
         defaultOption: true,
@@ -38,19 +43,22 @@ class Touch extends require('../Command') {
   }
 
   async touch(options) {
+    let sanitizedPath = Entry.sanitizePath(options.path)
+    if (sanitizedPath !== options.path) {
+      throw new Error('A filename cannot contain \\/><|:&?* chars.')
+    }
+    options.type = config.types.TEXT
     return await this.internalFs.make(options)
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     if (!options.path) {
       this.Logger.red('File path not specified.')
     } else {
       try {
-        let sanitizedPath = Entry.sanitizePath(options.path)
-        if (sanitizedPath !== options.path) {
-          throw new Error('A filename cannot contain \\/><|:&?* chars.')
-        }
-        options.type = config.types.TEXT
         await this.touch(options)
         this.Logger.grey(`New file "${options.path}" created.`)
       } catch (e) {

--- a/packages/secrez/src/commands/Ver.js
+++ b/packages/secrez/src/commands/Ver.js
@@ -16,7 +16,7 @@ class Ver extends require('../Command') {
     }
   }
 
-  async exec() {
+  async exec(options = {}) {
     this.Logger.reset(`v${pkg.version}`)
     this.prompt.run()
   }

--- a/packages/secrez/src/utils/Logger.js
+++ b/packages/secrez/src/utils/Logger.js
@@ -4,6 +4,15 @@ const path = require('path')
 
 let jsonIndent = 0
 
+
+chalk.blu = str => {
+  return chalk.rgb(40, 160, 210).dim(str)
+}
+
+chalk.agua = str => {
+  return chalk.rgb(40, 210, 160).dim(str)
+}
+
 class Logger {
 
   static red(str) {
@@ -27,7 +36,7 @@ class Logger {
   }
 
   static agua(str) {
-    console.info(chalk.rgb(40, 210, 160).dim(str))
+    Logger.log('agua', str)
   }
 
   static blue(str) {
@@ -51,7 +60,7 @@ class Logger {
   }
 
   static blu(str) {
-    console.info(chalk.rgb(10, 100, 210).dim(str))
+    Logger.log('blu', str)
   }
 
   static format(data) {
@@ -90,6 +99,8 @@ module.exports = Logger
 module.exports.debug = (...data) => {
   fs.appendFileSync(path.resolve(__dirname, '../../tmp/tmp.log'), '\n' + data.join(' '))
 }
+
+module.exports.chalk = chalk
 
 
 

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -1,0 +1,30 @@
+const _ = require('lodash')
+const YAML = require('yaml')
+const path = require('path')
+
+const utils = {
+
+  yamlParse: str => {
+    try {
+      return YAML.parse(str)
+    } catch (e) {
+      throw new Error('Cannot parse a malformed yaml')
+    }
+  },
+
+  yamlStringify: obj => {
+    return YAML.stringify(obj)
+  },
+
+  isYaml: filepath => {
+    try {
+      let ext = path.extname(filepath)
+      return /^\.y(a|)ml$/i.test(ext)
+    } catch (e) {
+      return false
+    }
+  }
+
+}
+
+module.exports = utils

--- a/packages/secrez/test/commands/Bash.test.js
+++ b/packages/secrez/test/commands/Bash.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Bash', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.bash.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
+
   })
 
   it('should show the content of an external file via bash', async function () {

--- a/packages/secrez/test/commands/Cd.test.js
+++ b/packages/secrez/test/commands/Cd.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Cd', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.cd.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
+
   })
 
   it('change to a folder', async function () {

--- a/packages/secrez/test/commands/Create.test.js
+++ b/packages/secrez/test/commands/Create.test.js
@@ -1,9 +1,9 @@
 const assert = require('chai').assert
-
+const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {noPrint} = require('../helpers')
+const {noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -17,7 +17,7 @@ describe('#Create', function () {
 
   let prompt
   let rootDir = path.resolve(__dirname, '../../tmp/test/.secrez')
-  let C
+  let inspect, C
 
   let options = {
     container: rootDir,
@@ -31,6 +31,16 @@ describe('#Create', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.create.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
+
   })
 
   it('should create a file', async function () {

--- a/packages/secrez/test/commands/Exit.test.js
+++ b/packages/secrez/test/commands/Exit.test.js
@@ -1,9 +1,10 @@
 const stdout = require('test-console').stdout
-
+const chai = require('chai')
+const assert = chai.assert
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 
 const {
   password,

--- a/packages/secrez/test/commands/Export.test.js
+++ b/packages/secrez/test/commands/Export.test.js
@@ -6,7 +6,7 @@ const clipboardy = require('clipboardy')
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, sleep, noPrint} = require('../helpers')
+const {assertConsole, sleep, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -34,6 +34,16 @@ describe('#Export', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.export.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[6]))
+
   })
 
   it('should export a file to the current local folder', async function () {

--- a/packages/secrez/test/commands/Find.test.js
+++ b/packages/secrez/test/commands/Find.test.js
@@ -1,9 +1,10 @@
 const stdout = require('test-console').stdout
-
+const chai = require('chai')
+const assert = chai.assert
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -31,6 +32,16 @@ describe('#Find', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.find.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
+
   })
 
   it('should show find a string in the tree', async function () {

--- a/packages/secrez/test/commands/Help.test.js
+++ b/packages/secrez/test/commands/Help.test.js
@@ -36,6 +36,16 @@ describe('#Help', function () {
     await prompt.internalFs.init()
   })
 
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.help.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/Available options/.test(output[1]))
+
+  })
+
   it('#exec and format', async function () {
 
     inspect = stdout.inspect()

--- a/packages/secrez/test/commands/Import.test.js
+++ b/packages/secrez/test/commands/Import.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Import', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.import.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[9]))
+
   })
 
   it('should import a file in the current folder', async function () {

--- a/packages/secrez/test/commands/Lcat.test.js
+++ b/packages/secrez/test/commands/Lcat.test.js
@@ -1,9 +1,10 @@
 const stdout = require('test-console').stdout
-
+const chai = require('chai')
+const assert = chai.assert
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +34,16 @@ describe('#Lcat', function () {
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
     await noPrint(C.lcd.exec({path: 'folder1'}))
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.lcat.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
+
   })
 
   it('cat a file', async function () {

--- a/packages/secrez/test/commands/Lcd.test.js
+++ b/packages/secrez/test/commands/Lcd.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 
 const {
   password,
@@ -34,6 +34,16 @@ describe('#Lcd', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.lcd.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
+
   })
 
   it('change to a folder', async function () {

--- a/packages/secrez/test/commands/Lls.test.js
+++ b/packages/secrez/test/commands/Lls.test.js
@@ -36,6 +36,16 @@ describe('#Lls', function () {
     await prompt.internalFs.init()
   })
 
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.lls.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
+
+  })
+
   it('should list a folder', async function () {
 
     inspect = stdout.inspect()

--- a/packages/secrez/test/commands/Lpwd.test.js
+++ b/packages/secrez/test/commands/Lpwd.test.js
@@ -1,9 +1,11 @@
 const stdout = require('test-console').stdout
+const chai = require('chai')
+const assert = chai.assert
 
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 
 const {
   password,
@@ -32,6 +34,16 @@ describe('#Lpwd', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.lpwd.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
+
   })
 
   it('change to a folder', async function () {

--- a/packages/secrez/test/commands/Ls.test.js
+++ b/packages/secrez/test/commands/Ls.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Ls', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.ls.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
 
   })
 
@@ -68,6 +78,12 @@ describe('#Ls', function () {
     await C.ls.exec({path: '/dir1/dir2A/dir6', list: true})
     inspect.restore()
     assert.isTrue(inspect.output.length === 0)
+
+
+    inspect = stdout.inspect()
+    await C.ls.exec({path: '/dir1/dir2A'})
+    inspect.restore()
+    assertConsole(inspect, ['dir6/    dir7/    '])
 
   })
 

--- a/packages/secrez/test/commands/Mkdir.test.js
+++ b/packages/secrez/test/commands/Mkdir.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Mkdir', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.mkdir.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
 
   })
 

--- a/packages/secrez/test/commands/Mv.test.js
+++ b/packages/secrez/test/commands/Mv.test.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const {config} = require('@secrez/core')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Mv', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.mv.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[5]))
 
   })
 

--- a/packages/secrez/test/commands/Pwd.test.js
+++ b/packages/secrez/test/commands/Pwd.test.js
@@ -1,9 +1,9 @@
+const assert = require('chai').assert
 const stdout = require('test-console').stdout
-
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -31,6 +31,16 @@ describe('#Pwd', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.pwd.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
 
   })
 

--- a/packages/secrez/test/commands/Rm.test.js
+++ b/packages/secrez/test/commands/Rm.test.js
@@ -1,11 +1,11 @@
 const stdout = require('test-console').stdout
-
+const assert = require('chai').assert
 const fs = require('fs-extra')
 const path = require('path')
 const {config} = require('@secrez/core')
 const {Node} = require('@secrez/fs')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Rm', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.rm.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[7]))
+
   })
 
   it('should delete a file with one version', async function () {

--- a/packages/secrez/test/commands/Touch.test.js
+++ b/packages/secrez/test/commands/Touch.test.js
@@ -5,7 +5,7 @@ const stdout = require('test-console').stdout
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -33,6 +33,16 @@ describe('#Touch', function () {
     C = prompt.commands
     await prompt.secrez.signup(password, iterations)
     await prompt.internalFs.init()
+
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.touch.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[6]))
 
   })
 

--- a/packages/secrez/test/commands/Ver.test.js
+++ b/packages/secrez/test/commands/Ver.test.js
@@ -1,9 +1,9 @@
 const stdout = require('test-console').stdout
-
+const assert = require('chai').assert
 const fs = require('fs-extra')
 const path = require('path')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole} = require('../helpers')
+const {assertConsole, decolorize} = require('../helpers')
 const pkg = require('../../package')
 
 const {

--- a/packages/secrez/test/fixtures/index.js
+++ b/packages/secrez/test/fixtures/index.js
@@ -11,5 +11,34 @@ module.exports = {
   iterations: 23456,
   iterationsB58: '7Yq',
   hash23456iterations: 'GCF7ytpi9DyMPbuDhLj6vW1oSe99nBTLzABcb1qvTeLY',
-  hash23456iterationsNoSalt: 'ErQE64oXPPs7QqbirznqzCap3KNyMKDZZZBexRfhS7Pb'
+  hash23456iterationsNoSalt: 'ErQE64oXPPs7QqbirznqzCap3KNyMKDZZZBexRfhS7Pb',
+  someYaml: `password: 93939393848484
+public_key: |
+  asdejwwjfajsfgajfgewjfgjgdajdgasjdgasdjagdsja
+  jfgewjfgjgdajdgasjdgasdjagdsjaasdejwwjfajsfga
+private_key: asdjahejkhkasdhaskjdhsakjdhewkhfwekfhfhasdjas
+command: ["redis-server", "--appendonly", "no"]
+expose:
+  - 6378
+ports:
+  - 6380:6379
+`,
+  someModifiedYaml: `password: 8763yetyss
+public_key: asdejwwjfajsfgajfgewjfgjgdajdgasjdgasdjagdsja
+command: ["redis-server", "--appendonly", "no"]
+ports:
+  - 6380:6379
+`,
+  someMoreModifiedYaml: `password: 93939393848484
+public_key: asdejwwjfajsfgajfgewjfgjgdajdgasjdgasdjagdsja
+private_key: asdjahejkhkasdhaskjdhsakjdhewkhfwekfhfhasdjas
+command: ["redis-server", "--appendonly", "no"]
+expose:
+  - 6379
+ports:
+  - 6380:6379
+urls:
+  - http://sacasa.co
+  - http://sasferre.in  
+`
 }

--- a/packages/secrez/test/utils/index.test.js
+++ b/packages/secrez/test/utils/index.test.js
@@ -1,0 +1,63 @@
+const chai = require('chai')
+const assert = chai.assert
+const {isYaml, yamlParse, yamlStringify} = require('../../src/utils')
+
+const yml = `key: |-
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  jasjhdkajsdhasdhaskdhaskjdhdsjkfhkdsfhksfhdskjfhkdhaskdhaskdhaskdhasdj
+  sdjdfdsfdjgdhjsdbcsdcnskdnafkjdsnfksandkasdnaknaskdnaskdnsadkasndasddk
+  askjfsdhfksfhkjesdhakdaj=
+  -----END OPENSSH PRIVATE KEY-----
+password: sada8893qne238n9e23e3qec93`
+
+const yml2 = 'pass: PASS\nkey: KEY'
+
+
+describe('#utils', function () {
+
+  describe('isYaml', async function () {
+
+    it('should return true if the file is a Yaml file', async function () {
+      assert.isTrue(isYaml('fule.yml'))
+      assert.isTrue(isYaml('fule.yaml'))
+      assert.isTrue(isYaml('fule.YAML'))
+      assert.isTrue(isYaml('fule.YmL'))
+      assert.isFalse(isYaml('fule.txt'))
+
+      assert.isFalse(isYaml(345))
+    })
+
+  })
+
+  describe('yamlParse', async function () {
+
+    it('should parse a Yaml string', async function () {
+      assert.equal(yamlParse(yml2).pass, 'PASS')
+      assert.isTrue(/-----END OPENSSH PRIVATE KEY-----/.test(yamlParse(yml).key))
+    })
+
+    it('should throw if the file is malformed', async function () {
+      try {
+        yamlParse('key:\nsasasasa\nsasas')
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'Cannot parse a malformed yaml')
+      }
+    })
+
+  })
+
+  describe('yamlStringify', async function () {
+
+    it('should stringify a Javascript object to a Yaml string', async function () {
+      assert.equal(yamlStringify({
+        pass: 'PASS'
+      }), 'pass: PASS\n')
+    })
+
+  })
+
+
+
+
+})


### PR DESCRIPTION
Adds support for simple cards based on the Yaml format.

The added cases are mostly related with Cat and Edit. In both case you can now specify a field option to cat only a specific field in a card. Same with Edit. A card must have extension `.yml`.
The option `-u, --unformatted` allows to edit or cat a file that is a yaml one but is not a card.

In this PR a `-h, --help` option has been added to any command that has an help.