### PR TITLE
Adding import from other password/secret managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,69 @@ This command takes the standard file myWallet.json, contained in the Desktop fol
 This is one of my favorite commands. In fact, let's say that you have just downloaded the private key to access your crypto wallet, you want to encrypt it as soon as possible. With Secrez, you can import the file and delete the cleartext version in one command.
 
 
+#### Importing from other password/secret managers
+
+From version 0.5.2, Secrez supports import of backups from other softwares.
+
+Suppose you have exported your password in a CSV file name export.csv like this:
+```
+Path,Username,Password,Web Site,Notes
+twitter/nick1,nick1@example.com,938eyehddu373,"http://cssasasa.com",
+facebook/account,fb@example.com,926734YYY,,
+somePath,,s83832jedjdj,"http://262626626.com","Multi
+line
+notes"
+```
+It is necessary a field named `path` because if not Secrez does not know where to put the new data. The path is supposed to be relative, allowing you to import it in your favorite folder.
+
+For example, to import it in the `1PasswordData` you could call
+```
+import export.csv -e 1PasswordData
+```
+The parameter `-e, --expand` is necessary. If missed, Secrez will import the file as a single file.
+
+Internally, Secrez converts the CSV in a JSON file like this:
+```
+ [
+    {
+      path: 'twitter/nick1',
+      username: 'nick1@example.com',
+      password: '938eyehddu373',
+      web_site: 'http://cssasasa.com'
+    },
+    {
+      path: 'facebook/account',
+      username: 'fb@example.com',
+      password: '926734YYY'
+    },
+    {
+      path: 'somePath',
+      password: 's83832jedjdj',
+      web_site: 'http://262626626.com',
+      notes: 'Multi\nline\nnotes'
+    }
+  ]
+```
+which means that you can also format your data as a JSON like that and import that directly with
+```
+import export.json -e 1PasswordData
+```
+
+Any item will generate a single Yaml file, like, for example, the last element in the JSON, will generate the file `/1PasswordDate/somePath.yml` with the following content:
+```
+password: s83832jedjdj
+web_site: http://262626626.com
+notes: |-
+  Multi
+  line
+  notes
+```
+
+When you edit the new file, Secrez recognize it as a card and asks you which field you want to edit (if you don't explicit it with, for example, `-f password`) and edit just that field.
+
+At the end of the process, you can remove the original backup, adding the option `-m`.
+You can also simulate the process to see which files will be created with the option `-s`.
+
 #### Some thoughts
 
 Secrez does not want to compete with password managers. So, don't expect in the future to have "form filling" and staff like that. The idea behind Secrez was born in 2017, when I was participating in many ICO and I had so many files to save and any password manager I used was very bad for that. Still, Secrez, for its nature, is file oriented and I guess will remain this way. However, it is open source, and someone is welcome to built a GUI or a mobile app built on it.

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/fs",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/fs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",

--- a/packages/fs/src/Tree.js
+++ b/packages/fs/src/Tree.js
@@ -244,16 +244,20 @@ class Tree {
     return normalized
   }
 
-  async getVersionedBasename(p) {
+  async getVersionedBasename(p, node = this.root) {
     p = this.getNormalizedPath(p)
     let dir = path.dirname(p)
     let fn = path.basename(p)
-    let name = fn
+    let ext = path.extname(p)
+    if (ext) {
+      fn = fn.replace(RegExp(ext.replace(/\./, '\\.') + '$'), '')
+    }
+    let name = fn + ext
     let v = 1
     for (; ;) {
       try {
-        this.root.getChildFromPath(path.join(dir, name))
-        name = fn + '.' + (++v)
+        node.getChildFromPath(path.join(dir, name))
+        name = fn + '.' + (++v) + ext
       } catch (e) {
         return name
       }
@@ -336,9 +340,6 @@ class Tree {
             )
             : ''
     await fs.writeFile(fullPath, encryptedContent)
-    // entry.set({
-    //   ts: Crypto.unscrambleTimestamp(entry.scrambledTs, entry.microseconds)
-    // })
     return entry
   }
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -1,5 +1,204 @@
 # Secrez
 A secrets manager in times of crypto coins.
 
-A documentation will come soon. For now, for info, look at https://github.com/secrez/secrez
+## This is a work in progress. Any suggestion, advice, critic is very welcome. But use at your own risk.
+
+
+### Intro
+
+Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `cp`, `ls`, `mv`, etc.
+
+The idea is to interact with encrypted virtual files as if they are just files in a standard file system. After running Secrez and logging in the local account, at the prompt, the user can execute commands.
+
+
+#### Why Secrez?
+
+There are two primary approaches to secrets and password management:
+
+1. Online systems that save the primary data online (like LastPass)
+2. Desktop tools who keep data in the computer (like KeyPass)
+
+As you know or can imagine, an Online Password Manager requires that you trust the remote server.
+I founded Passpack in 2006, and I know very well how, at any moment, you can add a backdoor, and probably nobody will notice it. A malicious service could also inject a backdoor only for a specific user.
+
+The second case, a desktop tool is intrinsically more secure, but it is hard to use on more than one computer.
+The standard solution is to back up the database on Dropbox or Google Drive and -- before using it -- download it locally, which is prone to produce unfixable problems and cause data loss.
+
+Secrez goal is to be as safe as KeyPass but available everywhere, like Lastpass.
+
+To obtain this goal, Secrez assembles a few strategies:
+
+- Any secret is a local file
+- Any file — besides if it is a tree version, a directory, a text file, or a binary file — is immutable
+- Any change can be pulled/pushed to a remote private repo
+
+You can create a private repo on, for example, GitHub.
+
+For now, this is a manual approach. Still, in a future version, GitHub credentials will be encrypted in Secrez, like any other data, and used directly to pull from the repo before doing any change and push to before exiting.
+
+In any case, even if you make changes parallelly, the changes won't generate any conflict because the files are immutable.
+
+#### Apparently lost secrets
+
+One of the primary goal of a secrets manager is that you will never lose any data.
+
+However, since only the most recent index is read, some secrets could be in the folder and not been loaded.
+
+Let do an example. Alice uses Secrez on computer A and computer B. The two data sets are aligned. Suddenly, GitHub is down and she has to make some change on both computers.
+
+When GitHub is up again, she pushes master on A and everything goes fine.
+
+She pulls on B and pushes.
+Now, the data online are not consistent because some secrets are in one index, some are in the other one.
+
+No problem. When Alice restart Secrez, the system finds the extra secrets, reads their positions from the previous indexes and puts them back in the tree.
+
+Since files are immutable, the strategy is not obvious. This is what happens in different cases:
+
+1. The recovered secret is in a folder that does not exists in the "official" index. In this case, the entire path is added using the encrypted data of the recovered secret
+2. The secret is a file in a folder that actually exists. The file is added as is, but the folders with existent paths are trashed.
+3. The secret is a file but a file with the same name exists in the same position. The system checks the content of the file. If it is the same, the secret is ignored, if not it is added as a version.
+
+Either any unused secret or secret that is rewritten (as a version) is trashed (you can check them in the `.trash` folder).
+
+In any case, all the content are kept.
+
+To avoid to repeat the same process on the other computer (which will generate files with different IDs and more deleted items), Alice should align the repo on A before doing anything there. But, if she does not, nothing will be lost anyway.
+
+#### The name convention
+
+A file name in Secrez looks like
+```
+1VAnGLojzCDWhfZRK8PCYK203WBzJkAA28FhKHdS7DM5SkJaTgYdGfN1MAjTdfUYSzvtDVsMJvGodoHWzMuK6zr
+```
+where `1` is the type (DIR, other types are TEXT and BINARY), and the rest is a encrypted message with nonce, in Base58 format.
+
+The encrypted part is the combination of id, timestamp, and actual filename.
+This implies that, at bootstrap, Secrez must read all the files' names and build a tree of the entire file system. This is done using particular files: trees. Only after reading all the data, Secrez is able to understand which is the tree and, if something is missed, add the missing secrets. Since everything is encrypted, there is no information deductible from the files on disk, except what you can deduct from the Git repo (mostly about versioning and timestamp). But the idea is to use a private repo, so this is a minor issue.
+
+To mitigate this risk, you can create a new Git repo, save everything as the first commit, and delete the previously used repo. This way, you lose the repo's history, but you also lose info about timestamps and versions in case someone gains access to the repo.
+
+_Secrez versions < 0.5.0 where scrambling the metadata. Talking with Nacl experts, it came out that that was an overkill, and it has been removed in version 0.5.0. If in the database there are previously encrypted data, they won't be "converted" because it would break the rule of file immutability. Be careful._
+
+#### The tree
+
+Secrez manages trees as single immutable files. During a session, temporary files are deleted to keep their number low, but at the exit, the last file remains in the repo.
+
+#### Security details
+
+When you initially create a secrez database (stored, by default, in `~/.secrez`) you should indicate the number of iterations.
+
+Since Secrez derives a master key from your password using `crypto.pbkdf2`, the number of iterations is a significant addition to the general security. Even if you use a not-very-hard-to-guess password, if the attacker does not know the number of iterations, he has to try all the possible ones. Considering that 2,000,000 iterations require a second or so, customizable iterations increases enormously the overall security.
+
+You can set up the number of iterations calling
+```
+secrez -i 1023896
+```
+or
+```
+secrez -si 876352
+```
+where the `-s` option saves the number locally in a git-ignored `env.json` file. This way you don't have to retype it all the time to launch Secrez (typing a wrong number of iterations, of course, will produce an error).
+
+If you don't explicitly set up the number of iterations, a value for that is asked during the set up, before your password, and is saved in `env.json`. If you put a large number and you think that it's too slow for your computer, delete the Secrez folder (by default `rm -rf ~/.secrez`) and restart.
+
+Other options are:
+
+- `-l` to set up the initial "external" folder on you computer
+- `-c` to set up the folder where the encrypted data are located
+
+Both are your homedir (`~`) by default.
+Basically, running Secrez with different containers (`-c` option) you can set up multiple independent encrypted databases.
+
+
+#### Install
+
+```
+npm install -g secrez
+```
+
+On same version of MacOS, there can be errors during the install. Search the Internet to find the solution.
+
+At first run, secrez will ask you for the number of iterations (suggested between 500000 and 1000000, but the more the better) and a master password — ideally a phrase hard to guess, but easy to remember and type, something like, for example "heavy march with 2 eggs" or "grace was a glad president".
+
+#### The commands
+
+Here, the output of `help`:
+
+```
+(/) Secrez $ help
+
+Available options:
+  bash    Execute a bash command in the current disk folder.
+  cat     Shows the content of a file.
+  cd      Changes the working directory.
+  create  Creates interactively a file containing a secret.
+  edit    Edits a file containing a secret.
+  exit    Exits TGT.
+  export  Export encrypted data to the OS in the current local folder
+  find    Find a secret.
+  help    This help.
+  import  Import files from the OS into the current folder
+  lcat    Similar to a standard cat in the external fs.
+  lcd     Changes the external working directory.
+  lls     Browses the external directories.
+  lpwd    Shows the path of the external working directory.
+  ls      Browses the directories.
+  mkdir   Creates a directory.
+  mv      Moves and renames files or folders.
+  pwd     Shows the path of the working directory.
+  rm      Removes a file or a single version of a file.
+  touch   Creates a file.
+  ver     Shows the version of Secrez.
+
+
+To get help about single commands, specify the command.
+
+Examples:
+  help list
+  help set
+```
+
+#### Some example
+
+```
+cat myPrivateKey
+```
+
+This command will show the content of an encrypted file, which is called `myPrivateKey`. In particular, it will show the latest version of the file.
+
+Adding options to the command, it is possible to either see a specific version or list all the versions.
+
+The versioning is very important in Secrez because the primary way to backup and distribute the data is using Git. In this case, you want to avoid conflicts that can be not fixable because of the encryption. So, every time there is a change, an entirely new file is created, with metadata about its id and timestamp.
+
+The timestamp is used to assign a version to the file. A version is a 4-letters hash of the timestamp.
+
+Another example:
+
+```
+import ~/Desktop/myWallet.json -m
+```
+
+This command takes the standard file myWallet.json, contained in the Desktop folder, encrypts it, saves it in the encrypted file system, and removes (-m) it from the original folder.
+
+This is one of my favorite commands. In fact, let's say that you have just downloaded the private key to access your crypto wallet, you want to encrypt it as soon as possible. With Secrez, you can import the file and delete the cleartext version in one command.
+
+
+#### Some thoughts
+
+Secrez does not want to compete with password managers. So, don't expect in the future to have "form filling" and staff like that. The idea behind Secrez was born in 2017, when I was participating in many ICO and I had so many files to save and any password manager I used was very bad for that. Still, Secrez, for its nature, is file oriented and I guess will remain this way. However, it is open source, and someone is welcome to built a GUI or a mobile app built on it.
+
+#### TODO
+
+- Documentation
+- More commands, included a Git command to manage the repo
+- Plugin architecture to allow others to add their own commands
+
+#### Copyright
+
+Secrez has been created by [Francesco Sullo](https://francesco.sullo.co) (<francesco@sullo.co>). Any opinion, help, suggestion, critic is very welcome.
+
+#### Licence
+
+[MIT](https://github.com/expressjs/express/blob/master/LICENSE)
 

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -9,7 +9,7 @@
     "all-tests": "find test/** -name '*.test.js' | xargs ./node_modules/.bin/mocha -R spec",
     "test-only": "./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
-    "posttest": "nyc check-coverage --statements 95 --branches 80 --functions 95 --lines 95"
+    "posttest": "nyc check-coverage --statements 95 --branches 75 --functions 95 --lines 95"
   },
   "nyc": {
     "include": "src",

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf build",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@secrez/core": "^0.5.0",
-    "@secrez/fs": "^0.5.0",
+    "@secrez/fs": "^0.5.1",
     "case": "^1.6.3",
     "chalk": "^3.0.0",
     "clipboardy": "^2.3.0",

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -108,7 +108,7 @@ class Edit extends require('../Command') {
     } else {
       delete options.field
     }
-    let node = this.tree.root.getChildFromPath(file)
+    let node = this.tree.workingNode.getChildFromPath(file)
     let content = options.field ? fields[options.field] || '' : data[0].content
     let message = 'your OS default editor.'
     if (options.internal) {

--- a/packages/secrez/src/commands/Import.js
+++ b/packages/secrez/src/commands/Import.js
@@ -142,7 +142,7 @@ class Import extends require('../Command') {
       if (ext === '.json') {
         data = JSON.parse(str)
       } else if (ext === '.csv') {
-        data = await fromCsvToJson(str)
+        data = fromCsvToJson(str)
       }
     } catch (e) {
       if (e.message === 'The header of the CSV looks wrong') {

--- a/packages/secrez/src/commands/Mv.js
+++ b/packages/secrez/src/commands/Mv.js
@@ -51,7 +51,7 @@ class Mv extends require('../Command') {
       if (!options.path) {
         throw new Error('An origin path is required.')
       } else {
-        if (this.tree.root.getChildFromPath(options.path)) {
+        if (this.tree.workingNode.getChildFromPath(options.path)) {
           let prompt = this.prompt
           let exitCode = Crypto.getRandomBase58String(2)
           let destination = options.destination

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -1,6 +1,8 @@
 const _ = require('lodash')
 const YAML = require('yaml')
 const path = require('path')
+const parse = require('csv-parse/lib/sync')
+const Case = require('case')
 
 const utils = {
 
@@ -23,6 +25,34 @@ const utils = {
     } catch (e) {
       return false
     }
+  },
+
+  fromCsvToJson: async (csv, delimiter = ',') => {
+    csv = csv.split('\n')
+    let firstLine = csv[0]
+    firstLine = parse(firstLine)[0].map(e => Case.snake(_.trim(e)))
+    let havePath = false
+    for (let e of firstLine) {
+      if (!/^[a-z]{1}[a-z0-9_]*$/.test(e)) {
+        throw new Error('The header of the CSV looks wrong')
+      }
+      if (e === 'path') {
+        havePath = true
+      }
+    }
+    if (!havePath) {
+      throw new Error('A "path" column in mandatory')
+    }
+    csv[0] = firstLine.join(',')
+    csv = csv.join('\n')
+    csv = parse(csv, {
+      columns: true,
+      skip_empty_lines: true,
+      delimiter,
+      skip_lines_with_error: true,
+      trim: true
+    })
+    return csv
   }
 
 }

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -27,10 +27,14 @@ const utils = {
     }
   },
 
-  fromCsvToJson: async (csv, delimiter = ',', skipEmpty = true) => {
+  fromCsvToJson: (csv, delimiter = ',', skipEmpty = true) => {
     csv = csv.split('\n')
     let firstLine = csv[0]
-    firstLine = parse(firstLine)[0].map(e => Case.snake(_.trim(e)))
+    try {
+      firstLine = parse(firstLine)[0].map(e => Case.snake(_.trim(e)))
+    } catch (e) {
+      throw new Error('The CSV is malformed')
+    }
     let havePath = false
     for (let e of firstLine) {
       if (!/^[a-z]{1}[a-z0-9_]*$/.test(e)) {

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -27,7 +27,7 @@ const utils = {
     }
   },
 
-  fromCsvToJson: async (csv, delimiter = ',') => {
+  fromCsvToJson: async (csv, delimiter = ',', skipEmpty = true) => {
     csv = csv.split('\n')
     let firstLine = csv[0]
     firstLine = parse(firstLine)[0].map(e => Case.snake(_.trim(e)))
@@ -45,14 +45,25 @@ const utils = {
     }
     csv[0] = firstLine.join(',')
     csv = csv.join('\n')
-    csv = parse(csv, {
+    let json = parse(csv, {
       columns: true,
       skip_empty_lines: true,
       delimiter,
       skip_lines_with_error: true,
       trim: true
     })
-    return csv
+    if (skipEmpty) {
+      json = json.map(e => {
+        let elem = {}
+        for (let key in e) {
+          if (e[key]) {
+            elem[key] = e[key]
+          }
+        }
+        return elem
+      })
+    }
+    return json
   }
 
 }

--- a/packages/secrez/test/commands/Lls.test.js
+++ b/packages/secrez/test/commands/Lls.test.js
@@ -52,8 +52,9 @@ describe('#Lls', function () {
     await C.lls.exec({path: '*'})
     inspect.restore()
     let str = decolorize(inspect.output.join('\n'))
-    assert.isTrue(/file3 +folder1/.test(str))
-
+    assert.isTrue(/file0\.txt/.test(str))
+    assert.isTrue(/file3/.test(str))
+    assert.isTrue(/folder1/.test(str))
   })
 
   it('return en error if lls-ing a not existing path', async function () {

--- a/packages/secrez/test/commands/Mv.test.js
+++ b/packages/secrez/test/commands/Mv.test.js
@@ -94,6 +94,34 @@ describe('#Mv', function () {
 
   })
 
+  it('should move a file to another subfolder', async function () {
+
+    let file = await C.touch.touch({
+      path: '/f1/f2/f3/f4.txt',
+      type: config.types.TEXT
+    })
+
+    let dir = await C.mkdir.mkdir({
+      path: '/f1/f5/f6',
+      type: config.types.DIR
+    })
+
+    await C.cd.cd({
+      path: '/f1/f2'
+    })
+
+    inspect = stdout.inspect()
+    await C.mv.exec({
+      path: 'f3/f4.txt',
+      destination: '../f5/f6/f4.txt'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'f3/f4.txt has been moved to ../f5/f6/f4.txt')
+
+    assert.equal(file.getPath(), '/f1/f5/f6/f4.txt')
+
+  })
+
   it('should move and rename file to another folder', async function () {
 
     let file1 = await C.touch.touch({

--- a/packages/secrez/test/fixtures/files/file0.txt
+++ b/packages/secrez/test/fixtures/files/file0.txt
@@ -1,0 +1,1 @@
+Three secrets

--- a/packages/secrez/test/fixtures/index.js
+++ b/packages/secrez/test/fixtures/index.js
@@ -40,5 +40,13 @@ ports:
 urls:
   - http://sacasa.co
   - http://sasferre.in  
-`
+`,
+  yml: `key: |-
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  jasjhdkajsdhasdhaskdhaskjdhdsjkfhkdsfhksfhdskjfhkdhaskdhaskdhaskdhasdj
+  sdjdfdsfdjgdhjsdbcsdcnskdnafkjdsnfksandkasdnaknaskdnaskdnsadkasndasddk
+  askjfsdhfksfhkjesdhakdaj=
+  -----END OPENSSH PRIVATE KEY-----
+password: sada8893qne238n9e23e3qec93`,
+  yml2: 'pass: PASS\nkey: KEY'
 }

--- a/packages/secrez/test/fixtures/some.csv
+++ b/packages/secrez/test/fixtures/some.csv
@@ -1,0 +1,14 @@
+Path,'Login Name',"Password",'Web Site',Comments,Tags
+"/webs/SampleEntryTitle","Greg","ycXfARD2G1AOBzLlhtbn","http://www.somepage.net","Some notes...","email eth"
+"/passwords/twitter/Multi-Line Test Entry",User,"bBbescXqkgGF21PK09gV","http://www.web.com","This is a multi-line comment.
+This is a multi-line comment.
+This is a multi-line comment.
+This is a multi-line comment.
+This is a multi-line comment.
+This is a multi-line comment.
+This is a multi-line comment.","some two"
+"/tests/Entry To Test/Special Characters","!""`§$%&/()=?´_#²³{[]}\\","öäüÖÄÜß€@<>µ©®","http://www.website.com","The user name and password fields contain special characters.",""
+"/tests/Entry To Test/JSON data/1",,,"http://www.web2.com","{""name"":""somename"",""nameSHA3"":""sadsasdasdasdas"",""owner"":""dssdsdsdsds"",""value"":""dsdsdsds"",""secret"":""skkajskajdksad"",""secretSHA3"":""0xjsajsadasjdajdjsajsjjajdas""}","eth web"
+
+"/error/skipped1",,
+"/error/skipped2",,,"http://www.web2.com",{"name":"somename","nameSHA3":"sadsasdasdasdas","owner":"dssdsdsdsds","value":"dsdsdsds","secret":"skkajskajdksad","secretSHA3":"0xjsajsadasjdajdjsajsjjajdas"},"web"

--- a/packages/secrez/test/fixtures/some.json
+++ b/packages/secrez/test/fixtures/some.json
@@ -1,0 +1,34 @@
+[
+  {
+    "path": "/webs/SampleEntryTitle",
+    "login_name": "Greg",
+    "password": "ycXfARD2G1AOBzLlhtbn",
+    "web_site": "http://www.somepage.net",
+    "comments": "Some notes...",
+    "tags": "email eth"
+  },
+  {
+    "path": "/passwords/twitter/Multi-Line Test Entry",
+    "login_name": "User",
+    "password": "bBbescXqkgGF21PK09gV",
+    "web_site": "http://www.web.com",
+    "comments": "This is a multi-line comment.\nThis is a multi-line comment.\nThis is a multi-line comment.\nThis is a multi-line comment.\nThis is a multi-line comment.\nThis is a multi-line comment.\nThis is a multi-line comment.",
+    "tags": "some two"
+  },
+  {
+    "path": "/tests/Entry To Test/Special Characters",
+    "login_name": "!\"`§$%&/()=?´_#²³{[]}\\\\",
+    "password": "öäüÖÄÜß€@<>µ©®",
+    "web_site": "http://www.website.com",
+    "comments": "The user name and password fields contain special characters.",
+    "tags": ""
+  },
+  {
+    "path": "/tests/Entry To Test/JSON data/1",
+    "login_name": "",
+    "password": "",
+    "web_site": "http://www.web2.com",
+    "comments": "{\"name\":\"somename\",\"nameSHA3\":\"sadsasdasdasdas\",\"owner\":\"dssdsdsdsds\",\"value\":\"dsdsdsds\",\"secret\":\"skkajskajdksad\",\"secretSHA3\":\"0xjsajsadasjdajdjsajsjjajdas\"}",
+    "tags": "eth web"
+  }
+]

--- a/packages/secrez/test/utils/index.test.js
+++ b/packages/secrez/test/utils/index.test.js
@@ -22,7 +22,7 @@ describe  ('#utils', function () {
 
     it('should convert a CSV file to an importable JSON file', async function () {
 
-      const result = await fromCsvToJson(csvSample)
+      const result = fromCsvToJson(csvSample)
       assert.equal(result.length, 4)
       assert.equal(Object.keys(result[0]).length, 6)
       assert.equal(result[0].login_name, 'Greg')
@@ -33,6 +33,30 @@ describe  ('#utils', function () {
         assert.equal(result[1][key], jsonSample[1][key])
       }
 
+    })
+
+    it('should throw if the CSV is bad or misses a path', async function () {
+      try {
+        fromCsvToJson('web,url,password\nssas,sasas,sasasa')
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'A "path" column in mandatory')
+      }
+
+      try {
+        fromCsvToJson('path,"öäü",password\nssas,sasas,sasasa')
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'The header of the CSV looks wrong')
+      }
+
+
+      try {
+        fromCsvToJson('path,"url{"sasa":3}",password\nssas,sasas,sasasa')
+        assert.isFalse(true)
+      } catch (e) {
+        assert.equal(e.message, 'The CSV is malformed')
+      }
     })
 
   })

--- a/packages/secrez/test/utils/index.test.js
+++ b/packages/secrez/test/utils/index.test.js
@@ -1,19 +1,41 @@
 const chai = require('chai')
 const assert = chai.assert
-const {isYaml, yamlParse, yamlStringify} = require('../../src/utils')
+const fs = require('fs-extra')
+const path = require('path')
+const jlog = require('../helpers/jlog')
+const {isYaml, yamlParse, yamlStringify, fromCsvToJson} = require('../../src/utils')
 
-const yml = `key: |-
-  -----BEGIN OPENSSH PRIVATE KEY-----
-  jasjhdkajsdhasdhaskdhaskjdhdsjkfhkdsfhksfhdskjfhkdhaskdhaskdhaskdhasdj
-  sdjdfdsfdjgdhjsdbcsdcnskdnafkjdsnfksandkasdnaknaskdnaskdnsadkasndasddk
-  askjfsdhfksfhkjesdhakdaj=
-  -----END OPENSSH PRIVATE KEY-----
-password: sada8893qne238n9e23e3qec93`
-
-const yml2 = 'pass: PASS\nkey: KEY'
+const {yml, yml2} = require('../fixtures')
 
 
-describe('#utils', function () {
+describe  ('#utils', function () {
+
+  let csvSample
+  let jsonSample
+
+  before(async function () {
+    csvSample = await fs.readFile(path.resolve(__dirname, '../fixtures/some.csv'), 'utf8')
+    jsonSample = require('../fixtures/some.json')
+  })
+
+  describe('fromCsvToJson', async function () {
+
+    it('should convert a CSV file to an importable JSON file', async function () {
+
+      const result = await fromCsvToJson(csvSample)
+      assert.equal(result.length, 4)
+      assert.equal(Object.keys(result[0]).length, 6)
+      assert.equal(result[0].login_name, 'Greg')
+      assert.equal(result[1].comments.split('\n').length, 7)
+      assert.equal(result[2].password, 'öäüÖÄÜß€@<>µ©®')
+
+      for (let key in result[1]) {
+        assert.equal(result[1][key], jsonSample[1][key])
+      }
+
+    })
+
+  })
 
   describe('isYaml', async function () {
 


### PR DESCRIPTION
This PR allows the import from password managers.

Suppose you have exported your password in a CSV file name export.csv like this:
```
Path,Username,Password,Web Site,Notes
twitter/nick1,nick1@example.com,938eyehddu373,"http://cssasasa.com",
facebook/account,fb@example.com,926734YYY,,
somePath,,s83832jedjdj,"http://262626626.com","Multi
line
notes"
```
It is necessary a field named `path` because if not Secrez does not know where to put the new data. The path is supposed to be relative, allowing you to import it in your favorite folder.

For example, to import it in the `1PasswordData` you could call
```
import export.csv -e 1PasswordData
```
The parameter `-e, --expand` is necessary. If missed, Secrez will import the file as a single file.

Internally, Secrez converts the CSV in a JSON file like this:
```
 [
    {
      path: 'twitter/nick1',
      username: 'nick1@example.com',
      password: '938eyehddu373',
      web_site: 'http://cssasasa.com'
    },
    {
      path: 'facebook/account',
      username: 'fb@example.com',
      password: '926734YYY'
    },
    {
      path: 'somePath',
      password: 's83832jedjdj',
      web_site: 'http://262626626.com',
      notes: 'Multi\nline\nnotes'
    }
  ]
```
which means that you can also format your data as a JSON like that and import that directly with
```
import export.json -e 1PasswordData
```

Any item will generate a single Yaml file, like, for example, the last element in the JSON, will generate the file `/1PasswordDate/somePath.yml` with the following content:
```
password: s83832jedjdj
web_site: http://262626626.com
notes: |-
  Multi
  line
  notes
```

When you edit the new file, Secrez recognize it as a card and asks you which field you want to edit (if you don't explicit it with, for example, `-f password`) and edit just that field.

At the end of the process, you can remove the original backup, adding the option `-m`.
You can also simulate the process to see which files will be created with the option `-s`.

This PR also fixes a bug in `mv` and `edit` that would not allow to find an internal file.