### PR TITLE
Optimize import disable intermediate tree saves

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ To obtain this goal, Secrez assembles a few strategies:
 - Any file — besides if it is a tree version, a directory, a text file, or a binary file — is immutable
 - Any change can be pulled/pushed to a remote private repo
 
-You can create a private repo on, for example, GitHub.
+You can either create a private repo on GitHub, BitBucket, etc. or — much better — setting your own, self-hosted git server.
 
-For now, this is a manual approach. Still, in a future version, GitHub credentials will be encrypted in Secrez, like any other data, and used directly to pull from the repo before doing any change and push to before exiting.
-
-In any case, even if you make changes parallelly, the changes won't generate any conflict because the files are immutable.
+For now, this is a manual approach. In a future version, the git repo will be manageable from inside Secrez.
 
 #### Apparently lost secrets
 

--- a/packages/fs/src/Tree.js
+++ b/packages/fs/src/Tree.js
@@ -149,7 +149,7 @@ class Tree {
           }
           this.alerts.push('Some files/versions have been recovered:')
           this.alerts = this.alerts.concat(recoveredEntries)
-          this.preSave()
+          await this.preSave()
         }
       }
     } else {
@@ -343,7 +343,19 @@ class Tree {
     return entry
   }
 
+  disableSave() {
+    this.skipPreSave = true
+  }
+
+  enableSave() {
+    delete this.skipPreSave
+  }
+
   async preSave() {
+    if (this.skipPreSave) {
+      // option used during imports with many entries, to optimize the performances
+      return
+    }
     let rootEntry = this.root.getEntry()
     if (this.previousRootEntry) {
       // this creates a single index file per session.

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Import.js
+++ b/packages/secrez/src/commands/Import.js
@@ -100,6 +100,7 @@ class Import extends require('../Command') {
 
       let result = []
       let moved = []
+      ifs.tree.disableSave()
       for (let fn of content) {
         let name = await this.tree.getVersionedBasename(path.basename(fn[0]))
         result.push(ifs.tree.getNormalizedPath(name))
@@ -114,9 +115,13 @@ class Import extends require('../Command') {
           })
         }
       }
-      if (options.move) {
-        for (let fn of moved) {
-          await fs.unlink(fn)
+      if (!options.simulate) {
+        ifs.tree.enableSave()
+        await ifs.tree.preSave()
+        if (options.move) {
+          for (let fn of moved) {
+            await fs.unlink(fn)
+          }
         }
       }
       return result.sort()
@@ -177,6 +182,7 @@ class Import extends require('../Command') {
     if (!Node.isDir(parentFolder)) {
       return this.Logger.red('The destination folder is not a folder.')
     }
+    ifs.tree.disableSave()
     for (let item of data) {
       let p = item.path
       if (!p) {
@@ -206,8 +212,12 @@ class Import extends require('../Command') {
         })
       }
     }
-    if (!options.simulate && options.move) {
-      await fs.unlink(fn)
+    if (!options.simulate) {
+      ifs.tree.enableSave()
+      await ifs.tree.preSave()
+      if (options.move) {
+        await fs.unlink(fn)
+      }
     }
   }
 


### PR DESCRIPTION
The first version of the import was saving an intermediate tree at any time a new folder or file was created. Since during the import of a backup from another software the can be hundreds or even thousands of entries, the intermediate saving was heavily slowing down the import. 
This PR disable temporarily the intermediate savings and saves the tree at the end of the process only one time.