### PR TITLE
Recognize tags during import, and Copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ __0.5.8__
 
 __0.5.7__
 * Add wildcard support for Import, Mv, Rm and Tag
+* Add support for recursion during import
 
 __0.5.6__
 * Add Tag command to tag files and folders

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Secrez
 A secrets manager in times of crypto coins.
 
-## This is a work in progress. Any suggestion, advice, critic is very welcome. But use at your own risk.
+### This is a work in progress. Any suggestion, advice, critic is very welcome. But use at your own risk.
 
 
-### Intro
+#### Intro
 
 Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `cp`, `ls`, `mv`, etc.
 
@@ -130,6 +130,7 @@ Available options:
   bash    Execute a bash command in the current disk folder.
   cat     Shows the content of a file.
   cd      Changes the working directory.
+  copy    Copy a text file to the clipboard.
   create  Creates interactively a file containing a secret.
   edit    Edits a file containing a secret.
   exit    Exits TGT.
@@ -146,9 +147,9 @@ Available options:
   mv      Moves and renames files or folders.
   pwd     Shows the path of the working directory.
   rm      Removes a file or a single version of a file.
+  tag     Tags a file and shows existent tags.
   touch   Creates a file.
   ver     Shows the version of Secrez.
-
 
 To get help about single commands, specify the command.
 
@@ -254,6 +255,39 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 - Documentation
 - More commands, included a Git command to manage the repo
 - Plugin architecture to allow others to add their own commands
+
+### History
+
+__0.5.8__
+* Allow Import, with the options `-t`, to recognize tags during the import from CSV
+* Split Export in Export and Copy. The first only exports to the FS, the second copies to the clipboard
+
+__0.5.7__
+* Add wildcard support for Import, Mv, Rm and Tag
+
+__0.5.6__
+* Add Tag command to tag files and folders
+
+__0.5.5__
+* Optimize Import avoiding intermediate saves of the tree
+* Fix an issue with iterations at launch
+
+__0.5.4__
+* Add Import of many entries from CSV and JSON files
+
+__0.5.3__
+* Use Yaml files as cards, being able to read and edit single fields
+
+__0.5.2__
+* Remove obfuscation of the tree before saving (it was an overkill)
+
+__0.5.1__
+* Add Find to search in files and folders
+
+__0.5.0__
+* First stable version
+
+Versions < 0.5.0 are deprecated because the format was sligtly different and they are incompatible.
 
 #### Copyright
 

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/fs",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/fs",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",

--- a/packages/fs/src/Tree.js
+++ b/packages/fs/src/Tree.js
@@ -349,6 +349,10 @@ class Tree {
     this.doNotSave = true
   }
 
+  isSaveEnabled() {
+    return this.doNotSave ? false : true
+  }
+
   enableSave() {
     delete this.doNotSave
   }
@@ -403,7 +407,11 @@ class Tree {
       }
       this.tagsChanged = true
     }
-    this.saveTags()
+    await this.saveTags()
+  }
+
+  getTags(node) {
+    return this.reverseTags()[node.id] || []
   }
 
   async removeTag(node, tags) {
@@ -414,10 +422,10 @@ class Tree {
         this.tagsChanged = true
       }
     }
-    this.saveTags()
+    await this.saveTags()
   }
 
-  async listTags() {
+  listTags() {
     let result = []
     let tags = this.tags.content
     for (let t of Object.keys(tags).sort()) {
@@ -426,7 +434,7 @@ class Tree {
     return result.sort()
   }
 
-  async getNodesByTag(list) {
+  getNodesByTag(list) {
     let result = []
     let tags = this.tags.content
     let tag = []

--- a/packages/fs/test/Tree.test.js
+++ b/packages/fs/test/Tree.test.js
@@ -174,22 +174,22 @@ describe('#Tree', function () {
       tree.enableSave()
       tree.saveTags()
 
-      let list = await tree.listTags()
+      let list = tree.listTags()
       assert.equal(list[0], 'web (2)')
       assert.equal(list[1], 'wib (1)')
       assert.equal(list[2], 'wob (2)')
 
       await tree.removeTag(b, ['web'])
-      list = await tree.listTags()
+      list = tree.listTags()
       assert.equal(list[0], 'web (1)')
 
-      let tagged = await tree.getNodesByTag(['wob'])
+      let tagged = tree.getNodesByTag(['wob'])
       assert.equal(tagged[0][0], '/b')
       assert.equal(tagged[0][1], 'wob')
       assert.equal(tagged[1][0], '/c')
       assert.equal(tagged[1][1], 'wib wob')
 
-      tagged = await tree.getNodesByTag(['wob', 'wib'])
+      tagged = tree.getNodesByTag(['wob', 'wib'])
       assert.equal(tagged[0][0], '/c')
       assert.equal(tagged[0][1], 'wib wob')
 

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@secrez/core": "^0.5.3",
-    "@secrez/fs": "^0.5.5",
+    "@secrez/fs": "^0.5.6",
     "case": "^1.6.3",
     "chalk": "^3.0.0",
     "clipboardy": "^2.3.0",

--- a/packages/secrez/src/commands/Copy.js
+++ b/packages/secrez/src/commands/Copy.js
@@ -1,0 +1,132 @@
+const path = require('path')
+const clipboardy = require('clipboardy')
+const {isYaml, yamlParse} = require('../utils')
+
+const {Node} = require('@secrez/fs')
+
+class Copy extends require('../Command') {
+
+  setHelpAndCompletion() {
+    this.cliConfig.completion.copy = {
+      _func: this.pseudoFileCompletion(this),
+      _self: this
+    }
+    this.cliConfig.completion.help.copy = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
+        name: 'path',
+        alias: 'p',
+        defaultOption: true,
+        type: String
+      },
+      {
+        name: 'duration',
+        alias: 'd',
+        type: Number
+      },
+      {
+        name: 'json',
+        alias: 'j',
+        type: Boolean
+      },
+      {
+        name: 'field',
+        alias: 'f',
+        type: String
+      },
+      {
+        name: 'version',
+        alias: 'v',
+        type: Boolean
+      }
+    ]
+  }
+
+  help() {
+    return {
+      description: [
+        'Copy a text file to the clipboard.'
+      ],
+      examples: [
+        ['copy ethKeys', 'copies to the clipboard for 10 seconds (the default)'],
+        ['copy google.yml -t 20 -f password', 'copies the password in the google card'],
+        ['copy google.yml -j', 'copies the google card as a JSON'],
+        ['copy myKey -v UY5d', 'copies version UY5d of myKey']
+      ]
+    }
+  }
+
+  async copy(options = {}) {
+    let ifs = this.internalFs
+    let cat = this.prompt.commands.cat
+    let p = this.tree.getNormalizedPath(options.path)
+    let file = ifs.tree.root.getChildFromPath(p)
+    if (Node.isFile(file)) {
+      let entry = (await cat.cat({
+        path: p,
+        version: options.version,
+        unformatted: true
+      }))[0]
+      if (options.clipboard) {
+        if (Node.isText(entry)) {
+          let {name, content} = entry
+          if (isYaml(p)) {
+            let err = 'Field not found.'
+            try {
+              let parsed = yamlParse(content)
+              if (options.json) {
+                content = JSON.stringify(parsed, null, 2)
+              } else if (options.field) {
+                if (parsed[options.field]) {
+                  content = parsed[options.field]
+                } else {
+                  throw new Error(err)
+                }
+              }
+            } catch(e) {
+              if (e.message === err) {
+                throw new Error(`Field "${options.field}" not found in "${path.basename(p)}"`)
+              } else if (options.json || options.field) {
+                throw new Error('The yml is malformed. To copy the entire content, do not use th options -j or -f')
+              }
+            }
+          }
+          await clipboardy.write(content)
+          setTimeout(async () => {
+            if (content === (await clipboardy.read())) {
+              await clipboardy.write('')
+            }
+          }, 1000 * options.clipboard)
+          return name
+        } else {
+          throw new Error('You can copy to clipboard only text files.')
+        }
+      }
+    } else {
+      throw new Error('Cannot copy a folder')
+    }
+  }
+
+  async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
+    try {
+      let name = await this.copy(options)
+      this.Logger.agua('Copied to clipboard:')
+      this.Logger.reset(name)
+    } catch (e) {
+      this.Logger.red(e.message)
+    }
+    this.prompt.run()
+  }
+}
+
+module.exports = Copy
+
+

--- a/packages/secrez/src/commands/Mv.js
+++ b/packages/secrez/src/commands/Mv.js
@@ -39,12 +39,15 @@ class Mv extends require('../Command') {
 
   async mv(options, nodes) {
     if (nodes) {
+      this.tree.disableSave()
       for (let node of nodes) {
         await this.internalFs.change({
           path: node.getPath(),
           newPath: options.newPath
         })
       }
+      this.tree.enableSave()
+      this.tree.save()
     } else {
       await this.internalFs.change({
         path: options.path,

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -68,7 +68,17 @@ const utils = {
       })
     }
     return json
+  },
+
+  fromSimpleYamlToJson: yml => {
+    yml = yml.split('\n').map(e =>  e.split(': '))
+    let json = {}
+    for (let y of yml) {
+      json[y[0]] = y[1]
+    }
+    return json
   }
+
 
 }
 

--- a/packages/secrez/test/commands/Copy.test.js
+++ b/packages/secrez/test/commands/Copy.test.js
@@ -1,0 +1,195 @@
+const chai = require('chai')
+const assert = chai.assert
+const stdout = require('test-console').stdout
+const clipboardy = require('clipboardy')
+const fs = require('fs-extra')
+const path = require('path')
+
+const {yamlParse} = require('../../src/utils')
+const Prompt = require('../mocks/PromptMock')
+const {assertConsole, sleep, noPrint, decolorize} = require('../helpers')
+
+const {
+  password,
+  iterations
+} = require('../fixtures')
+
+// eslint-disable-next-line no-unused-vars
+const jlog = require('../helpers/jlog')
+
+describe('#Copy', function () {
+
+  let prompt
+  let rootDir = path.resolve(__dirname, '../../tmp/test/.secrez')
+  let inspect, C
+
+  let options = {
+    container: rootDir,
+    localDir: path.resolve(__dirname, '../../tmp/test')
+  }
+
+  beforeEach(async function () {
+    await fs.emptyDir(path.resolve(__dirname, '../../tmp/test'))
+    prompt = new Prompt
+    await prompt.init(options)
+    C = prompt.commands
+    await prompt.secrez.signup(password, iterations)
+    await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.copy.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
+
+  })
+
+  it('should copy a file to the clipboard', async function () {
+
+    let content = 'Some secret'
+    let p = '/folder/file'
+    await noPrint(C.touch.exec({
+      path: p,
+      content
+    }))
+
+    await noPrint(C.cd.exec({
+      path: '/folder'
+    }))
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: 'file',
+      clipboard: 1
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Copied to clipboard:', 'file'])
+
+    await sleep(100)
+    assert.equal(await clipboardy.read(), content)
+
+    await sleep(1000)
+    assert.isFalse(!!await clipboardy.read())
+
+  })
+
+  it('should copy a card to the clipboard', async function () {
+
+    let content = 'password: s7s7s7s7s\npin: 3625\nnickname: geoge'
+    let p = 'card.yml'
+    await noPrint(C.touch.exec({
+      path: p,
+      content
+    }))
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: p,
+      clipboard: 1,
+      json: true
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
+
+    await sleep(100)
+    assert.equal(await clipboardy.read(), JSON.stringify(yamlParse(content), null, 2))
+
+    await sleep(1000)
+    assert.isFalse(!!await clipboardy.read())
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: p,
+      clipboard: 1,
+      field: 'password'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
+
+    await sleep(100)
+    assert.equal(await clipboardy.read(), 's7s7s7s7s')
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: p,
+      clipboard: 1,
+      field: 'none'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Field "none" not found in "card.yml"'])
+
+    await noPrint(prompt.internalFs.change({
+      path: p,
+      content: content += '\ncasas:\nasakdjakddkadkasd'
+    }))
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: p,
+      clipboard: 1,
+      field: 'password'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['The yml is malformed. To copy the entire content, do not use th options -j or -f'])
+
+
+  })
+
+  it('should return an error if the file does not exist or is a folder', async function () {
+
+    await noPrint(C.mkdir.exec({
+      path: '/folder'
+    }))
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: '/folder'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Cannot copy a folder'])
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: '/some'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Path does not exist'])
+
+
+  })
+
+  it('should throw if copying to clipboard a binary files', async function () {
+
+    await noPrint(C.mkdir.exec({
+      path: '/folder'
+    }))
+    await noPrint(C.cd.exec({
+      path: '/folder'
+    }))
+    await noPrint(C.lcd.exec({
+      path: '../../test/fixtures/files'
+    }))
+    await noPrint(C.import.exec({
+      path: 'folder1/file1.tar.gz',
+      'binary-too': true
+    }))
+    await noPrint(C.lcd.exec({
+      path: '../../../tmp/test'
+    }))
+
+    inspect = stdout.inspect()
+    await C.copy.exec({
+      path: 'file1.tar.gz',
+      clipboard: 10
+    })
+    inspect.restore()
+    assertConsole(inspect, ['You can copy to clipboard only text files.'])
+
+
+  })
+
+})
+

--- a/packages/secrez/test/commands/Export.test.js
+++ b/packages/secrez/test/commands/Export.test.js
@@ -1,13 +1,11 @@
 const chai = require('chai')
 const assert = chai.assert
 const stdout = require('test-console').stdout
-const clipboardy = require('clipboardy')
 const fs = require('fs-extra')
 const path = require('path')
 
-const {yamlParse} = require('../../src/utils')
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, sleep, noPrint, decolorize} = require('../helpers')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
 
 const {
   password,
@@ -43,7 +41,7 @@ describe('#Export', function () {
     await C.export.exec({help: true})
     inspect.restore()
     let output = inspect.output.map(e => decolorize(e))
-    assert.isTrue(/-h, --help/.test(output[6]))
+    assert.isTrue(/-h, --help/.test(output[5]))
 
   })
 
@@ -83,97 +81,6 @@ describe('#Export', function () {
 
   })
 
-  it('should export a file to the clipboard', async function () {
-
-    let content = 'Some secret'
-    let p = '/folder/file'
-    await noPrint(C.touch.exec({
-      path: p,
-      content
-    }))
-
-    await noPrint(C.cd.exec({
-      path: '/folder'
-    }))
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: 'file',
-      clipboard: 1
-    })
-    inspect.restore()
-    assertConsole(inspect, ['Copied to clipboard:', 'file'])
-
-    await sleep(100)
-    assert.equal(await clipboardy.read(), content)
-
-    await sleep(1000)
-    assert.isFalse(!!await clipboardy.read())
-
-  })
-
-  it('should export a card to the clipboard', async function () {
-
-    let content = 'password: s7s7s7s7s\npin: 3625\nnickname: geoge'
-    let p = 'card.yml'
-    await noPrint(C.touch.exec({
-      path: p,
-      content
-    }))
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: p,
-      clipboard: 1,
-      json: true
-    })
-    inspect.restore()
-    assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
-
-    await sleep(100)
-    assert.equal(await clipboardy.read(), JSON.stringify(yamlParse(content), null, 2))
-
-    await sleep(1000)
-    assert.isFalse(!!await clipboardy.read())
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: p,
-      clipboard: 1,
-      field: 'password'
-    })
-    inspect.restore()
-    assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
-
-    await sleep(100)
-    assert.equal(await clipboardy.read(), 's7s7s7s7s')
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: p,
-      clipboard: 1,
-      field: 'none'
-    })
-    inspect.restore()
-    assertConsole(inspect, ['Field "none" not found in "card.yml"'])
-
-    await noPrint(prompt.internalFs.change({
-      path: p,
-      content: content += '\ncasas:\nasakdjakddkadkasd'
-    }))
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: p,
-      clipboard: 1,
-      field: 'password'
-    })
-    inspect.restore()
-    assertConsole(inspect, ['The yml is malformed. To copy the entire content, do not use th options -j or -f'])
-
-
-  })
-
   it('should return an error if the file does not exist or is a folder', async function () {
 
     await noPrint(C.mkdir.exec({
@@ -193,36 +100,6 @@ describe('#Export', function () {
     })
     inspect.restore()
     assertConsole(inspect, ['Path does not exist'])
-
-
-  })
-
-  it('should throw if copying to clipboard a binary files', async function () {
-
-    await noPrint(C.mkdir.exec({
-      path: '/folder'
-    }))
-    await noPrint(C.cd.exec({
-      path: '/folder'
-    }))
-    await noPrint(C.lcd.exec({
-      path: '../../test/fixtures/files'
-    }))
-    await noPrint(C.import.exec({
-      path: 'folder1/file1.tar.gz',
-      'binary-too': true
-    }))
-    await noPrint(C.lcd.exec({
-      path: '../../../tmp/test'
-    }))
-
-    inspect = stdout.inspect()
-    await C.export.exec({
-      path: 'file1.tar.gz',
-      clipboard: 10
-    })
-    inspect.restore()
-    assertConsole(inspect, ['You can copy to clipboard only text files.'])
 
 
   })


### PR DESCRIPTION
During the import, if there is a field names `tags` and the import is launched with the `-t, --tags` options, the tags are recognized and the files are labeled accordingly. For example:
```
import some.csv -te /from1password
```

This PR also splits `Export` in two commands: `Export` and `Copy`.
The first just exports to the file system, while the second copies to the clipboard.
