### PR TITLE
Paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.5.9__
+* Add Paste to paste the clipboard content in either a new or existent file, emptying the clipboard
+* Fix bug with Copy that was preventing the command from working
+
 __0.5.8__
 * Allow Import, with the options `-t`, to recognize tags during the import from CSV
 * Split Export in Export and Copy. The first only exports to the FS, the second copies to the clipboard

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Available options:
   ls      Browses the directories.
   mkdir   Creates a directory.
   mv      Moves and renames files or folders.
+  paste   Paste whatever is in the clipboard in an encrypted entries.
   pwd     Shows the path of the working directory.
   rm      Removes a file or a single version of a file.
   tag     Tags a file and shows existent tags.

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Cat.js
+++ b/packages/secrez/src/commands/Cat.js
@@ -84,6 +84,11 @@ class Cat extends require('../Command') {
   }
 
   async cat(options, justContent) {
+    if (typeof options === 'string') {
+      options = {
+        path: options
+      }
+    }
     let p = this.tree.getNormalizedPath(options.path)
     let node = this.tree.root.getChildFromPath(p)
     if (node && Node.isFile(node)) {

--- a/packages/secrez/src/commands/Copy.js
+++ b/packages/secrez/src/commands/Copy.js
@@ -72,40 +72,38 @@ class Copy extends require('../Command') {
         version: options.version,
         unformatted: true
       }))[0]
-      if (options.clipboard) {
-        if (Node.isText(entry)) {
-          let {name, content} = entry
-          if (isYaml(p)) {
-            let err = 'Field not found.'
-            try {
-              let parsed = yamlParse(content)
-              if (options.json) {
-                content = JSON.stringify(parsed, null, 2)
-              } else if (options.field) {
-                if (parsed[options.field]) {
-                  content = parsed[options.field]
-                } else {
-                  throw new Error(err)
-                }
+      if (Node.isText(entry)) {
+        let {name, content} = entry
+        if (isYaml(p)) {
+          let err = 'Field not found.'
+          try {
+            let parsed = yamlParse(content)
+            if (options.json) {
+              content = JSON.stringify(parsed, null, 2)
+            } else if (options.field) {
+              if (parsed[options.field]) {
+                content = parsed[options.field]
+              } else {
+                throw new Error(err)
               }
-            } catch(e) {
-              if (e.message === err) {
-                throw new Error(`Field "${options.field}" not found in "${path.basename(p)}"`)
-              } else if (options.json || options.field) {
-                throw new Error('The yml is malformed. To copy the entire content, do not use th options -j or -f')
-              }
+            }
+          } catch (e) {
+            if (e.message === err) {
+              throw new Error(`Field "${options.field}" not found in "${path.basename(p)}"`)
+            } else if (options.json || options.field) {
+              throw new Error('The yml is malformed. To copy the entire content, do not use th options -j or -f')
             }
           }
-          await clipboardy.write(content)
-          setTimeout(async () => {
-            if (content === (await clipboardy.read())) {
-              await clipboardy.write('')
-            }
-          }, 1000 * options.clipboard)
-          return name
-        } else {
-          throw new Error('You can copy to clipboard only text files.')
         }
+        await clipboardy.write(content)
+        setTimeout(async () => {
+          if (content === (await clipboardy.read())) {
+            await clipboardy.write('')
+          }
+        }, 1000 * (options.duration || 10))
+        return name
+      } else {
+        throw new Error('You can copy to clipboard only text files.')
       }
     } else {
       throw new Error('Cannot copy a folder')

--- a/packages/secrez/src/commands/Mkdir.js
+++ b/packages/secrez/src/commands/Mkdir.js
@@ -36,6 +36,11 @@ class Mkdir extends require('../Command') {
   }
 
   async mkdir(options) {
+    if (typeof options === 'string') {
+      options = {
+        path: options
+      }
+    }
     await this.internalFs.make(options)
   }
 

--- a/packages/secrez/src/commands/Mkdir.js
+++ b/packages/secrez/src/commands/Mkdir.js
@@ -36,11 +36,6 @@ class Mkdir extends require('../Command') {
   }
 
   async mkdir(options) {
-    if (typeof options === 'string') {
-      options = {
-        path: options
-      }
-    }
     await this.internalFs.make(options)
   }
 

--- a/packages/secrez/src/commands/Paste.js
+++ b/packages/secrez/src/commands/Paste.js
@@ -1,0 +1,121 @@
+const clipboardy = require('clipboardy')
+const {isYaml, yamlParse, yamlStringify} = require('../utils')
+
+const {Node} = require('@secrez/fs')
+
+class Paste extends require('../Command') {
+
+  setHelpAndCompletion() {
+    this.cliConfig.completion.paste = {
+      _func: this.pseudoFileCompletion(this),
+      _self: this
+    }
+    this.cliConfig.completion.help.paste = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
+        name: 'path',
+        alias: 'p',
+        defaultOption: true,
+        type: String
+      },
+      {
+        name: 'append',
+        alias: 'a',
+        type: Boolean
+      },
+      {
+        name: 'field',
+        alias: 'f',
+        type: String
+      }
+    ]
+  }
+
+  help() {
+    return {
+      description: [
+        'Paste whatever is in the clipboard in an encrypted entries.'
+      ],
+      examples: [
+        ['paste ethKeys.json', 'pastes in ethKeys.json even if it exists'],
+        ['paste -a -p google.txt', 'pastes appending the content to the existent content in google.txt'],
+        ['paste yahoo.yml -f password', 'pastes the field password in the card']
+      ]
+    }
+  }
+
+  async paste(options = {}) {
+    let ifs = this.internalFs
+    let cat = this.prompt.commands.cat
+    let p = this.tree.getNormalizedPath(options.path)
+    let file
+    let existingContent
+    try {
+      file = ifs.tree.root.getChildFromPath(p)
+      existingContent = (await cat.cat({path: p, unformatted: true}))[0].content
+    } catch (e) {
+      //
+    }
+    if (file && !Node.isFile(file)) {
+      throw new Error('Cannot paste to a folder or a binary file')
+    }
+    let content = await clipboardy.read()
+    if (!content) {
+      throw new Error('The clipboard does not contain any text')
+    }
+    if (isYaml(p) && options.field) {
+      let parsed = {}
+      if (existingContent) {
+        try {
+          parsed = yamlParse(existingContent)
+        } catch (e) {
+          throw new Error('The yaml file exists but it is malformed.')
+        }
+      }
+      parsed[options.field] = content
+      content = yamlStringify(parsed)
+    }
+    if (file) {
+      if (options.append) {
+        content = existingContent + '\n' + content
+      }
+      await ifs.change({
+        path: p,
+        content
+      })
+    } else {
+      await ifs.make({
+        path: p,
+        type: this.cliConfig.types.TEXT,
+        content
+      })
+    }
+    await clipboardy.write('')
+
+    return options.path
+
+  }
+
+  async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
+    try {
+      let name = await this.paste(options)
+      this.Logger.agua('Pasted the clipboard to:')
+      this.Logger.reset(name)
+    } catch (e) {
+      this.Logger.red(e.message)
+    }
+    this.prompt.run()
+  }
+}
+
+module.exports = Paste
+
+

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -79,7 +79,6 @@ const utils = {
     return json
   }
 
-
 }
 
 module.exports = utils

--- a/packages/secrez/test/commands/Copy.test.js
+++ b/packages/secrez/test/commands/Copy.test.js
@@ -63,7 +63,7 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: 'file',
-      clipboard: 1
+      duration: 1
     })
     inspect.restore()
     assertConsole(inspect, ['Copied to clipboard:', 'file'])
@@ -88,7 +88,7 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: p,
-      clipboard: 1,
+      duration: 1,
       json: true
     })
     inspect.restore()
@@ -103,7 +103,7 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: p,
-      clipboard: 1,
+      duration: 1,
       field: 'password'
     })
     inspect.restore()
@@ -115,7 +115,7 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: p,
-      clipboard: 1,
+      duration: 1,
       field: 'none'
     })
     inspect.restore()
@@ -129,7 +129,7 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: p,
-      clipboard: 1,
+      duration: 1,
       field: 'password'
     })
     inspect.restore()
@@ -182,8 +182,7 @@ describe('#Copy', function () {
 
     inspect = stdout.inspect()
     await C.copy.exec({
-      path: 'file1.tar.gz',
-      clipboard: 10
+      path: 'file1.tar.gz'
     })
     inspect.restore()
     assertConsole(inspect, ['You can copy to clipboard only text files.'])

--- a/packages/secrez/test/commands/Import.test.js
+++ b/packages/secrez/test/commands/Import.test.js
@@ -67,7 +67,7 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, ['Imported files:', '/folder/file0.txt'])
 
-    let newSecret = await C.cat.cat({path: '/folder/file0.txt'})
+    let newSecret = await C.cat.cat('/folder/file0.txt')
     assert.equal(newSecret[0].type, prompt.secrez.config.types.TEXT)
     assert.equal(newSecret[0].content, content)
 

--- a/packages/secrez/test/commands/Paste.test.js
+++ b/packages/secrez/test/commands/Paste.test.js
@@ -1,0 +1,122 @@
+const chai = require('chai')
+const assert = chai.assert
+const stdout = require('test-console').stdout
+const clipboardy = require('clipboardy')
+const fs = require('fs-extra')
+const path = require('path')
+
+const {yamlParse} = require('../../src/utils')
+const Prompt = require('../mocks/PromptMock')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
+
+const {
+  password,
+  iterations
+} = require('../fixtures')
+
+// eslint-disable-next-line no-unused-vars
+const jlog = require('../helpers/jlog')
+
+describe('#Paste', function () {
+
+  let prompt
+  let rootDir = path.resolve(__dirname, '../../tmp/test/.secrez')
+  let inspect, C
+
+  let options = {
+    container: rootDir,
+    localDir: path.resolve(__dirname, '../../tmp/test')
+  }
+
+  beforeEach(async function () {
+    await fs.emptyDir(path.resolve(__dirname, '../../tmp/test'))
+    prompt = new Prompt
+    await prompt.init(options)
+    C = prompt.commands
+    await prompt.secrez.signup(password, iterations)
+    await prompt.internalFs.init()
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.paste.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[4]))
+
+  })
+
+  it('should paste the clipboard content to a new file', async function () {
+
+    let content = 'Some secret'
+    await clipboardy.write(content)
+
+    inspect = stdout.inspect()
+    await C.paste.exec({
+      path: 'file'
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Pasted the clipboard to:', 'file'])
+
+    assert.equal((await C.cat.cat({path: 'file'}))[0].content, content)
+    assert.equal(await clipboardy.read(), '')
+
+  })
+
+  it('should paste the clipboard content to an existent file', async function () {
+
+    let p = 'some/path'
+    let content = 'Some secret'
+    await noPrint(
+        C.touch.exec({
+      path: p,
+      content
+    }))
+
+    let newContent = 'New secret'
+    await clipboardy.write(newContent)
+    await noPrint(C.paste.exec({
+      path: p
+    }))
+
+    assert.equal((await C.cat.cat({path: p}))[0].content, newContent)
+
+    let addedContent = 'Added secret'
+    await clipboardy.write(addedContent)
+    await noPrint(C.paste.exec({
+      path: p,
+      append: true
+    }))
+
+    assert.equal((await C.cat.cat({path: p}))[0].content, newContent + '\n' + addedContent)
+
+  })
+
+  it('should paste a single field to a yml card', async function () {
+
+    let p = 'card.yml'
+    let username = 'john'
+    let content = `username: ${username}`
+    await noPrint(
+        C.touch.exec({
+          path: p,
+          content
+        }))
+
+    let password = '7sy3ge5stwg3'
+    await clipboardy.write(password)
+    await noPrint(C.paste.exec({
+      path: p,
+      field: 'password'
+    }))
+
+    let data = (await C.cat.cat({path: p, unformatted: true}))[0].content
+    data = yamlParse(data)
+    assert.equal(data.username, username)
+    assert.equal(data.password, password)
+
+  })
+
+})
+


### PR DESCRIPTION
News in version 0.5.9:
* Add Paste to paste the clipboard content in either a new or existent file, emptying the clipboard
* Fix bug with Copy that was preventing the command from working
