### PR TITLE
Using tags to format paths

### DIFF
--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Help.js
+++ b/packages/secrez/src/commands/Help.js
@@ -72,7 +72,7 @@ class Help extends require('../Command') {
                       : '         '
               ),
               'grey',
-              c.hint ? ' (' + c.hint +')' : ''
+              c.hint ? ' (' + c.hint + ')' : ''
           )
         }
       }
@@ -81,25 +81,37 @@ class Help extends require('../Command') {
       console.info()
       this.Logger.reset('Examples:')
       let max = 0
-      let c = ''
       for (let e of data.examples) {
         if (Array.isArray(e)) {
-          c = `(${e[1]})`
           e = e[0]
         }
         max = Math.max(max, e.length)
       }
       for (let e of data.examples) {
-        c = ''
+        if (typeof e === 'string') {
+          e = [e]
+        }
+        let s = e[0]
         if (Array.isArray(e)) {
-          c = `(${e[1]})`
-          e = e[0]
+          e = e.slice(1)
+          let len = e.length
+          if (len > 0) {
+            for (let j = 0; j < len; j++) {
+              let c = e[j]
+              this.Logger.log('black', spacer + (
+                  j
+                      ? ' '.repeat(max + 3)
+                      : s + ' '.repeat(max - s.length + 1)
+              ), 'grey', [
+                !j ? '(' : '',
+                c,
+                len === 1 || j === len -1 ? ')' : ''
+              ].join(''))
+            }
+            continue
+          }
         }
-        if (c) {
-          this.Logger.log('black', spacer + e + ' '.repeat(max - e.length + 1), 'grey', c)
-        } else {
-          this.Logger.reset(spacer + e)
-        }
+        this.Logger.reset(spacer + s)
       }
     }
     console.info()

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -27,11 +27,7 @@ const utils = {
     }
   },
 
-  fromCsvToJson: (
-      csv,
-      delimiter = ',',
-      skipEmpty = true
-  ) => {
+  fromCsvToJson: (csv, delimiter = ',', skipEmpty = true) => {
     csv = csv.split('\n')
     let firstLine = csv[0]
     try {

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -27,7 +27,11 @@ const utils = {
     }
   },
 
-  fromCsvToJson: (csv, delimiter = ',', skipEmpty = true) => {
+  fromCsvToJson: (
+      csv,
+      delimiter = ',',
+      skipEmpty = true
+  ) => {
     csv = csv.split('\n')
     let firstLine = csv[0]
     try {
@@ -35,17 +39,10 @@ const utils = {
     } catch (e) {
       throw new Error('The CSV is malformed')
     }
-    let havePath = false
     for (let e of firstLine) {
       if (!/^[a-z]{1}[a-z0-9_]*$/.test(e)) {
         throw new Error('The header of the CSV looks wrong')
       }
-      if (e === 'path') {
-        havePath = true
-      }
-    }
-    if (!havePath) {
-      throw new Error('A "path" column in mandatory')
     }
     csv[0] = firstLine.join(',')
     csv = csv.join('\n')
@@ -71,7 +68,7 @@ const utils = {
   },
 
   fromSimpleYamlToJson: yml => {
-    yml = yml.split('\n').map(e =>  e.split(': '))
+    yml = yml.split('\n').map(e => e.split(': '))
     let json = {}
     for (let y of yml) {
       json[y[0]] = y[1]

--- a/packages/secrez/test/utils/index.test.js
+++ b/packages/secrez/test/utils/index.test.js
@@ -34,13 +34,7 @@ describe  ('#utils', function () {
 
     })
 
-    it('should throw if the CSV is bad or misses a path', async function () {
-      try {
-        fromCsvToJson('web,url,password\nssas,sasas,sasasa')
-        assert.isFalse(true)
-      } catch (e) {
-        assert.equal(e.message, 'A "path" column in mandatory')
-      }
+    it('should throw if the CSV is bad', async function () {
 
       try {
         fromCsvToJson('path,"öäü",password\nssas,sasas,sasasa')


### PR DESCRIPTION
Some password managers organize items in a folders-like structure. Some other, like Passpack, use tags to organize the items. When you import a CSV from a software like that, you would end up putting all the imported entries in a single folder. With this new changes, if you import with something like
```
import -u frompasspack.csv /some/folder
```
All the tags will be formatted to prefix the path, based on tag weight. For example, let say that you have a CSV like
```
path,password,tags
Google,8e8e8373u3,web email
YahooMail,4848jejddh,app email
```
the CSV will be transformed into
```
path,password,tags
email/web/Google,8e8e8373u3,
email/app/YahooMail,4848jejddh,
```
Notice that the tags will be removed.
If you want to keep them anyway, you can use the normal `tags` option like:
```
import -ut frompasspack.csv /some/folder
```
