### PR TITLE
Fix minor bug in Tag

### DIFF
--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",
-    "test-only": "./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
+    "test-only": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
     "posttest": "nyc check-coverage --statements 95 --branches 75 --functions 95 --lines 95"
   },

--- a/packages/secrez/src/commands/Help.js
+++ b/packages/secrez/src/commands/Help.js
@@ -1,4 +1,6 @@
 const chalk = require('chalk')
+const utils = require('../utils')
+
 class Help extends require('../Command') {
 
   setHelpAndCompletion() {
@@ -85,8 +87,8 @@ class Help extends require('../Command') {
     if (data.examples.length) {
       this.Logger.reset('Examples:')
       let max = 0
-      const cols = process.stdout.columns
-          || 80 // workaround for lerna testing
+      const cols = utils.getCols()
+
       let MAX = parseInt(cols * 2 / 6)
       for (let e of data.examples) {
         if (Array.isArray(e)) {

--- a/packages/secrez/src/commands/Tag.js
+++ b/packages/secrez/src/commands/Tag.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const {chalk} = require('../utils/Logger')
 const Case = require('case')
 const {Node} = require('@secrez/fs')
+const utils = require('../utils')
 
 class Tag extends require('../Command') {
 
@@ -151,7 +152,7 @@ class Tag extends require('../Command') {
       for (let datasetIndex in isSaveEnabled) {
         if (isSaveEnabled[datasetIndex]) {
           this.internalFs.trees[datasetIndex].enableSave()
-          this.internalFs.trees[datasetIndex].saveTags()
+          await this.internalFs.trees[datasetIndex].saveTags()
         }
       }
       return result
@@ -160,8 +161,7 @@ class Tag extends require('../Command') {
   }
 
   formatResult(result) {
-    const cols = process.stdout.columns
-        || 80 // workaround for lerna testing
+    const cols = utils.getCols()
 
     let max = 0
     let mak = 0

--- a/packages/secrez/src/utils/index.js
+++ b/packages/secrez/src/utils/index.js
@@ -72,6 +72,10 @@ const utils = {
     return json
   },
 
+  getCols: () => {
+    return process.env.NODE_ENV === 'test' ? 80 : (process.stdout.columns || 80)
+  },
+
   TRUE: () => true
 
 }

--- a/packages/secrez/test/commands/Tag.test.js
+++ b/packages/secrez/test/commands/Tag.test.js
@@ -93,6 +93,7 @@ describe('#Tag', function () {
       add: ['email', 'web']
     }))
 
+    // console.log(1)
     inspect = stdout.inspect()
     await C.tag.exec({
       path: '/f2',
@@ -101,10 +102,14 @@ describe('#Tag', function () {
     inspect.restore()
     assertConsole(inspect, ['Tag removed'])
 
+    // console.log(2)
+
     await noPrint(C.tag.exec({
       path: '/f2',
       add: ['email']
     }))
+
+    // console.log(3)
 
     inspect = stdout.inspect()
     await C.tag.exec({


### PR DESCRIPTION
Set the number of columns to 80 during testing to avoid unpredictable results.
Fix a minor bug in Tag causing a test to generate an alert.