### PR TITLE
Adding aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.6.4__
+* add `alias` to generate alias of any command
+
+__0.6.3__
+* Minor bug fix
+
 __0.6.2__
 * `copy` can put many fields in the clipboard, scheduling them
 

--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ This is one of my favorite commands. In fact, let's say that you have just downl
 Suppose that you have a card for your bank and like to login to your bank. You could copy email and password to the clipboard to paste them in the browser. Suppose that you expect to be able in 4 seconds to move from the terminal to the browser, you could run the command:    
 
 ```
-copy bank.yml -f email password -t 4 3
+copy bank.yml -f email password -d 4 3
 ```
 This will copy the email field and give you 4 seconds to paste it in the browser. After it will emit a beep and you have 3 seconds to paste the password. It sounds quite useful, but **it can be better.**
 
 If you use that login often, you could like to create an alias for it with:
 ```
-alias b -c "copy bank.yml -f email password -t 4 3"
+alias b -c "copy bank.yml -f email password -d 4 3"
 ```
 Next time, you can just type
 ```

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ A secrets manager as an encrypted file system.
 
 #### Intro
 
-Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `cp`, `ls`, `mv`, etc.
+Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `mkdir`, `ls`, `mv`, etc.
 
-The idea is to interact with encrypted virtual files as if they are just files in a standard file system. After running Secrez and logging in the local account, at the prompt, the user can execute commands.
+The idea is to interact with encrypted virtual files as if they are just files in a standard file system.
 
 
 #### Why Secrez?
 
 There are two primary approaches to secrets and password management:
 
-1. Online systems that save the primary data online (like LastPass)
+1. Online systems that save the data online (like LastPass)
 2. Desktop tools who keep data in the computer (like KeyPass)
 
 An Online Password Manager requires that you trust the remote server.
-I founded Passpack in 2006, and I know very well how, at any moment, you can add a backdoor, and probably nobody will notice it. A malicious service could also inject a backdoor only for a specific user.
+I founded Passpack in 2006, and I know very well how, at any moment, you can add a backdoor —— even only for a specific user —— and most likely nobody will notice it.
 
 The second case, a desktop tool is intrinsically more secure, but it is hard to use on more than one computer.
-The standard solution is to back up the database on Dropbox or Google Drive and -- before using it -- download it locally, which is prone to produce unfixable problems and cause data loss.
+The standard solution is to backup the database on Dropbox or Google Drive and —— before using it —— download it locally, which is prone to produce unfixable problems and cause data loss.
 
-Secrez goal is to be as safe as KeyPass but available everywhere, like Lastpass.
+Secrez's goal is to be as safe as KeyPass but available everywhere, like Lastpass.
 
 To obtain this goal, Secrez assembles a few strategies:
 
@@ -40,7 +40,7 @@ For now, this is a manual approach. In a future version, the git repo will be ma
 
 Secrez simulates an operating system. When you load the environment, you can execute commands like `ls`, `mv`, etc. similarly to what you normally to in a Unix terminal.
 
-Starting from version `0.6.0`, the data are organized in datasets. This of them like separate disks, something like `/dev/disk1` and `/dev/disk2`.
+Starting from version `0.6.0`, the data are organized in datasets. Think of them like separate disks, something like `/dev/disk1` and `/dev/disk2`.
 
 By default, Secrez generates two datasets: `main` and `trash`. You can create more with, for example, `use -c archive`. The advantage of multiple datasets is mostly for people who have a lot of secrets to manage. If you have 2,000, if they are all in the primary dataset, the system will probably become quite slow. The solution is to move data to separate datasets (`archive`, `backup`, `twitter`, `cryptos`, etc.)
 
@@ -68,7 +68,7 @@ Since files are immutable, the strategy is not obvious. This is what happens in 
 
 Either any unused secret or secret that is rewritten (as a version) is trashed (you can check them in the `trash` dataset).
 
-In any case, all the content are kept.
+In any case, all the contents are kept.
 
 To avoid to repeat the same process on the other computer (which will generate files with different IDs and more deleted items), Alice should align the repo on A before doing anything there. But, if she does not, nothing will be lost anyway.
 
@@ -123,8 +123,6 @@ Basically, running Secrez with different containers (`-c` option) you can set up
 npm install -g secrez
 ```
 
-On same version of MacOS, there can be errors during the install. Search the Internet to find the solution.
-
 At first run, secrez will ask you for the number of iterations (suggested between 500000 and 1000000, but the more the better) and a master password — ideally a phrase hard to guess, but easy to remember and type, something like, for example "heavy march with 2 eggs" or "grace was a glad president".
 
 #### The commands
@@ -169,6 +167,50 @@ Examples:
   import -h   ()
   
 ```
+
+#### Some example
+
+```
+cat myPrivateKey
+```
+
+This command will show the content of an encrypted file, which is called `myPrivateKey`. In particular, it will show the latest version of the file.
+
+Adding options to the command, it is possible to either see a specific version or list all the versions.
+
+The versioning is very important in Secrez because the primary way to backup and distribute the data is using Git. In this case, you want to avoid conflicts that can be not fixable because of the encryption. So, every time there is a change, an entirely new file is created, with metadata about its id and timestamp.
+
+The timestamp is used to assign a version to the file. A version is a 4-letters hash of the timestamp.
+
+Another example:
+
+```
+import ~/Desktop/myWallet.json -m
+```
+
+This command takes the standard file myWallet.json, contained in the Desktop folder, encrypts it, saves it in the encrypted file system, and removes (-m) it from the original folder.
+
+This is one of my favorite commands. In fact, let's say that you have just downloaded the private key to access your crypto wallet, you want to encrypt it as soon as possible. With Secrez, you can import the file and delete the cleartext version in one command.
+
+#### Aliases — where the fun comes :-)
+
+Suppose that you have a card for your bank and like to login to your bank. You could copy email and password to the clipboard to paste them in the browser. Suppose that you expect to be able in 4 seconds to move from the terminal to the browser, you could run the command:    
+
+```
+copy bank.yml -f email password -t 4 3
+```
+This will copy the email field and give you 4 seconds to paste it in the browser. After it will emit a beep and you have 3 seconds to paste the password. It sounds quite useful, but **it can be better.**
+
+If you use that login often, you could like to create an alias for it with:
+```
+alias b -c "copy bank.yml -f email password -t 4 3"
+```
+Next time, you can just type
+```
+b
+```
+and press enter to execute that command. It's fantastic, isn't it?
+
 
 #### Importing from other password/secret managers
 
@@ -238,18 +280,17 @@ If in the CSV file there is also the field `tags`, you can tag automatically any
 
 #### Second factor authentication
 
-Secrez uses external scripts in Python, based on  Python-Fido2 by Yubiko, and it's compatible with any Fido2 authenticator device implementing the hmac-secret extension.
+Since version 0.6.1, Secrez supports 2FA. It uses external scripts in Python, based on  Python-Fido2 by Yubiko, and it's compatible with any Fido2 authenticator device implementing the hmac-secret extension.
 
 To register a new fido2 key with the name `solo`, you can call
 
 ```
 conf -r solo --fido2
 ```
-If some of the requirements are missing, you will see an error message.
 
-After activating the first fido2 key, Secrez asks if you also want to generate an emergency recovery code. It allows you to recover the account if all the registered keys are lost.
+When you activate the first fido2 key, Secrez asks if you also want to generate an emergency recovery code. It allows you to recover the account if all the registered keys are lost.
 
-You can set more than one, with a command like:
+You can set more keys and more recovery codes. For the latter, with a command like:
 
 ```
 conf -r memo --recovery-code
@@ -279,9 +320,9 @@ If solo is the only USB device you set, Secrez removes all the recovery codes an
 
 **Risks**
 
-Adding or removing a second factor changes the keys.json file. So, if you are using a git repository, be sure you don't create conflicts, i.e., don't change the second factor configuration in more computer parallely because you risk to damage your data.
+Adding or removing a second factor changes the keys.json file. So, if you are using a git repository, be sure you don't create conflicts, i.e., don't change the second factor configuration in more computer parallelly because you risk to damage your data.
 
-As a rule of thumb, if you use a git repo, always commit and push before changing the configuration.
+As a rule of thumb, if you use a git repo, always pull before running Secrez, and always commit and push after exiting.
 
 #### Some thoughts
 

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/fs",
-	"version": "0.6.6",
+	"version": "0.6.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/fs",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",

--- a/packages/fs/src/DataCache.js
+++ b/packages/fs/src/DataCache.js
@@ -3,50 +3,103 @@ const fs = require('fs-extra')
 
 class DataCache {
 
-  constructor(dataPath) {
+  constructor(dataPath, secrez) {
+    this.secrez = secrez
     this.cache = {}
     if (dataPath) {
       this.dataPath = dataPath
       fs.ensureDirSync(dataPath)
       this.ensured = {}
+      this.encrypted = {}
     }
   }
 
-  async load(key) {
+  async reset() {
+    if (this.cache && process.env.NODE_ENV === 'test') {
+      if (this.dataPath) {
+        await fs.emptyDir(this.dataPath)
+      }
+      this.cache = {}
+      this.ensured = {}
+      this.encrypted = {}
+    }
+  }
+
+  async load(key, isEncrypted) {
     if (this.dataPath) {
       this.ensure(key)
-      let files = await fs.readdir(path.join(this.dataPath, key))
-      this.puts(key, files, true)
-    }
-  }
-
-  async puts(key, value, dontSave, dontWait) {
-    if (!this.cache[key]) {
-      this.cache[key] = []
-    }
-    if (!Array.isArray(value)) {
-      value = [value]
-    }
-    for (let v of value) {
-      if (!this.cache[key].includes(v)) {
-        this.cache[key].push(v)
-        if (!dontSave) {
-          if (dontWait) {
-            this.save(key, v)
-          } else {
-            await this.save(key, v)
+      let p = path.join(this.dataPath, key)
+      let files = await fs.readdir(p)
+      if (isEncrypted) {
+        this.encrypted[key] = true
+      }
+      for (let i = 0; i < files.length; i++) {
+        let content = await fs.readFile(path.join(p, files[i]), 'utf8')
+        if (isEncrypted) {
+          files[i] = {
+            encryptedValue: files[i],
+            value: this.secrez.decryptData(files[i]),
+          }
+          if (content) {
+            files[i].content = this.secrez.decryptData(content)
+          }
+        } else {
+          files[i] = {
+            value: files[i]
+          }
+          if (content) {
+            files[i].content = content
           }
         }
       }
+      return this.puts(key, files, true)
     }
+    return false
   }
 
-  get(key) {
-    return this.cache[key] || []
+  async puts(key, data, dontSave, dontWait) {
+    if (!this.cache[key]) {
+      this.cache[key] = {}
+    }
+    if (!Array.isArray(data)) {
+      data = [data]
+    }
+    let counter = 0
+    for (let v of data) {
+      if (typeof v === 'string') {
+        v = {
+          value: v
+        }
+      }
+      if (!dontSave) {
+        if (dontWait && !this.encrypted[key]) {
+          this.save(key, v)
+        } else {
+          v = await this.save(key, v)
+        }
+      }
+      let value = v.value
+      delete v.value
+      this.cache[key][value] = v
+      counter++
+    }
+    return counter
+  }
+
+  list(key) {
+    return Object.keys(this.get(key))
+  }
+
+  get(key, value) {
+    let all = this.cache[key] || {}
+    if (value) {
+      all = all[value]
+    }
+    return all
   }
 
   is(key, value) {
-    return (this.cache[key] || []).includes(value)
+    return !!this.get(key, value)
   }
 
   ensure(key) {
@@ -56,10 +109,30 @@ class DataCache {
     }
   }
 
-  async save(key, value) {
+  async save(key, data) {
     if (this.dataPath) {
       this.ensure(key)
-      await fs.writeFile(path.join(this.dataPath, key, value), '')
+      let value = data.value
+      let content = data.content || ''
+      if (this.encrypted[key]) {
+        value = this.secrez.encryptData(value)
+        content = content ? this.secrez.encryptData(content) : ''
+      }
+      await fs.writeFile(path.join(this.dataPath, key, value), content)
+      data.encryptedValue = value
+      return data
+    }
+    return data
+  }
+
+  async remove(key, value) {
+    let data = this.get(key, value)
+    if (data) {
+      await fs.unlink(path.join(this.dataPath, key, data.encryptedValue || data.value))
+      delete this.cache[key][value]
+      return true
+    } else {
+      return false
     }
   }
 

--- a/packages/fs/src/InternalFs.js
+++ b/packages/fs/src/InternalFs.js
@@ -280,6 +280,9 @@ class InternalFs {
       end = undefined
     }
     try {
+      if (/\?|\*/.test(path.basename(p))) {
+        throw new Error()
+      }
       node = tree.root.getChildFromPath(p)
     } catch (e) {
       end = path.basename(p)

--- a/packages/fs/src/Node.js
+++ b/packages/fs/src/Node.js
@@ -13,7 +13,7 @@ class Node {
     }
   }
 
-  static getCache(dataCache) {
+  static getCache() {
     return cache
   }
 
@@ -39,13 +39,10 @@ class Node {
       if (entry.id) {
         this.id = entry.id
       } else {
-        this.id = Crypto.getRandomId(cache ? cache.get('id') : null)
+        this.id = Crypto.getRandomId(cache ? cache.list('id') : null)
+        cache.puts('id', this.id)
       }
-      cache.puts('id', this.id)
     }
-    this.id = isRoot ? config.specialId.ROOT
-        : isTrash ? config.specialId.TRASH
-            : entry.id || Crypto.getRandomId(cache.get('id'))
 
     if (Node.isDir(entry)) {
       this.children = {}

--- a/packages/fs/test/DataCache.test.js
+++ b/packages/fs/test/DataCache.test.js
@@ -3,38 +3,77 @@ const assert = chai.assert
 const path = require('path')
 const fs = require('fs-extra')
 const DataCache = require('../src/DataCache')
-const {sleep} = require('./helpers')
+const {Secrez} = require('@secrez/core')
+
+const {
+  password,
+  iterations
+} = require('./fixtures')
 
 describe('#DataCache', function () {
 
-  let cacheDir = path.resolve(__dirname, '../tmp/cache')
+  let testDir = path.resolve(__dirname, '../tmp/test')
+  let rootDir = path.join(testDir, '.secrez')
+  let cacheDir = path.join(testDir, '.secrez/cache')
+  let dataCache
+  let secrez
 
   beforeEach(async function () {
-    await fs.emptyDir(cacheDir)
+    await fs.emptyDir(testDir)
+    secrez = new Secrez()
+    await secrez.init(rootDir)
+    await secrez.signup(password, iterations)
+    dataCache = new DataCache(cacheDir, secrez)
   })
 
   it('should initialize a dataCache', async function () {
-    let dataCache = new DataCache(cacheDir)
     assert.equal(dataCache.dataPath, cacheDir)
   })
 
   it('should put and get data', async function () {
-    let dataCache = new DataCache(cacheDir)
     await dataCache.puts('key', ['one', 'two', 'three'])
-    assert.equal(dataCache.get('key').length, 3)
+    assert.equal(dataCache.list('key').length, 3)
     assert.isTrue(dataCache.is('key', 'two'))
-    dataCache.puts('key', ['zero'], false, true)
-    await sleep(100)
+    await dataCache.puts('key', ['zero'])
     assert.isTrue(dataCache.is('key', 'zero'))
   })
 
   it('should load data from disk, if any', async function () {
-    let dataCache = new DataCache(cacheDir)
+    await dataCache.load('key')
     await dataCache.puts('key', ['one', 'two', 'three'])
     dataCache = new DataCache(cacheDir)
     await dataCache.load('key')
-    assert.equal(dataCache.get('key').length, 3)
+    assert.equal(dataCache.list('key').length, 3)
     assert.isTrue(dataCache.is('key', 'two'))
+  })
+
+
+  it('should load encrypted data from disk, if any', async function () {
+    await dataCache.load('encKey', true)
+    await dataCache.puts('encKey', [{
+      value: 'one', content: 'uno'
+    }, {
+      value: 'two', content: 'due'
+    }, {
+      value: 'three', content: 'tre'
+    }])
+    dataCache = new DataCache(cacheDir, secrez)
+    await dataCache.load('encKey', true)
+    assert.equal(dataCache.list('encKey').length, 3)
+    assert.isTrue(dataCache.is('encKey', 'two'))
+
+    await dataCache.remove('encKey', 'one')
+    assert.equal(dataCache.list('encKey').length, 2)
+
+    dataCache = new DataCache(cacheDir, secrez)
+    await dataCache.load('encKey', true)
+    assert.equal(dataCache.list('encKey').length, 2)
+
+    await dataCache.puts('encKey', [{
+      value: 'four'
+    }], false, true)
+
+    assert.equal(dataCache.list('encKey').length, 3)
   })
 
 

--- a/packages/fs/test/Node.test.js
+++ b/packages/fs/test/Node.test.js
@@ -3,7 +3,6 @@ const fs = require('fs-extra')
 const util = require('util')
 const path = require('path')
 const {config, Secrez, Crypto, Entry} = require('@secrez/core')
-const DataCache = require('../src/DataCache')
 const Node = require('../src/Node')
 const {jsonEqual, initRandomNode, setNewNodeVersion, initARootNode} = require('./helpers')
 const {ENTRY_EXISTS} = require('../src/Messages')
@@ -18,6 +17,8 @@ const jlog = require('./helpers/jlog')
 
 describe('#Node', function () {
 
+  let testDir = path.resolve(__dirname, '../tmp/test')
+  fs.emptyDirSync(testDir)
   let secrez
   let rootDir = path.resolve(__dirname, '../tmp/test/.secrez')
   const D = config.types.DIR
@@ -30,14 +31,6 @@ describe('#Node', function () {
       let root = initARootNode()
       assert.equal(root.id, config.specialId.ROOT)
 
-    })
-
-    it('should setup the cache and instantiate the Node', async function () {
-
-      let p = path.resolve(__dirname, '../tmp/cache')
-      let cache = new DataCache(p)
-      Node.setCache(cache)
-      assert.equal(Node.getCache().dataPath, p)
     })
 
     it('should throw if passing a rot without required parameters', async function () {

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -336,6 +336,12 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.6.4__
+* add `alias` to generate alias of any command
+
+__0.6.3__
+* Minor bug fix
+
 __0.6.2__
 * `copy` can put many fields in the clipboard, scheduling them
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -197,13 +197,13 @@ This is one of my favorite commands. In fact, let's say that you have just downl
 Suppose that you have a card for your bank and like to login to your bank. You could copy email and password to the clipboard to paste them in the browser. Suppose that you expect to be able in 4 seconds to move from the terminal to the browser, you could run the command:    
 
 ```
-copy bank.yml -f email password -t 4 3
+copy bank.yml -f email password -d 4 3
 ```
 This will copy the email field and give you 4 seconds to paste it in the browser. After it will emit a beep and you have 3 seconds to paste the password. It sounds quite useful, but **it can be better.**
 
 If you use that login often, you could like to create an alias for it with:
 ```
-alias b -c "copy bank.yml -f email password -t 4 3"
+alias b -c "copy bank.yml -f email password -d 4 3"
 ```
 Next time, you can just type
 ```

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -6,25 +6,25 @@ A secrets manager as an encrypted file system.
 
 #### Intro
 
-Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `cp`, `ls`, `mv`, etc.
+Secrez is a CLI application that manages a particular encrypted file system, with commands working similarly to Unix commands like `cd`, `mkdir`, `ls`, `mv`, etc.
 
-The idea is to interact with encrypted virtual files as if they are just files in a standard file system. After running Secrez and logging in the local account, at the prompt, the user can execute commands.
+The idea is to interact with encrypted virtual files as if they are just files in a standard file system.
 
 
 #### Why Secrez?
 
 There are two primary approaches to secrets and password management:
 
-1. Online systems that save the primary data online (like LastPass)
+1. Online systems that save the data online (like LastPass)
 2. Desktop tools who keep data in the computer (like KeyPass)
 
 An Online Password Manager requires that you trust the remote server.
-I founded Passpack in 2006, and I know very well how, at any moment, you can add a backdoor, and probably nobody will notice it. A malicious service could also inject a backdoor only for a specific user.
+I founded Passpack in 2006, and I know very well how, at any moment, you can add a backdoor —— even only for a specific user —— and most likely nobody will notice it.
 
 The second case, a desktop tool is intrinsically more secure, but it is hard to use on more than one computer.
-The standard solution is to back up the database on Dropbox or Google Drive and -- before using it -- download it locally, which is prone to produce unfixable problems and cause data loss.
+The standard solution is to backup the database on Dropbox or Google Drive and —— before using it —— download it locally, which is prone to produce unfixable problems and cause data loss.
 
-Secrez goal is to be as safe as KeyPass but available everywhere, like Lastpass.
+Secrez's goal is to be as safe as KeyPass but available everywhere, like Lastpass.
 
 To obtain this goal, Secrez assembles a few strategies:
 
@@ -40,7 +40,7 @@ For now, this is a manual approach. In a future version, the git repo will be ma
 
 Secrez simulates an operating system. When you load the environment, you can execute commands like `ls`, `mv`, etc. similarly to what you normally to in a Unix terminal.
 
-Starting from version `0.6.0`, the data are organized in datasets. This of them like separate disks, something like `/dev/disk1` and `/dev/disk2`.
+Starting from version `0.6.0`, the data are organized in datasets. Think of them like separate disks, something like `/dev/disk1` and `/dev/disk2`.
 
 By default, Secrez generates two datasets: `main` and `trash`. You can create more with, for example, `use -c archive`. The advantage of multiple datasets is mostly for people who have a lot of secrets to manage. If you have 2,000, if they are all in the primary dataset, the system will probably become quite slow. The solution is to move data to separate datasets (`archive`, `backup`, `twitter`, `cryptos`, etc.)
 
@@ -68,7 +68,7 @@ Since files are immutable, the strategy is not obvious. This is what happens in 
 
 Either any unused secret or secret that is rewritten (as a version) is trashed (you can check them in the `trash` dataset).
 
-In any case, all the content are kept.
+In any case, all the contents are kept.
 
 To avoid to repeat the same process on the other computer (which will generate files with different IDs and more deleted items), Alice should align the repo on A before doing anything there. But, if she does not, nothing will be lost anyway.
 
@@ -123,8 +123,6 @@ Basically, running Secrez with different containers (`-c` option) you can set up
 npm install -g secrez
 ```
 
-On same version of MacOS, there can be errors during the install. Search the Internet to find the solution.
-
 At first run, secrez will ask you for the number of iterations (suggested between 500000 and 1000000, but the more the better) and a master password — ideally a phrase hard to guess, but easy to remember and type, something like, for example "heavy march with 2 eggs" or "grace was a glad president".
 
 #### The commands
@@ -169,6 +167,50 @@ Examples:
   import -h   ()
   
 ```
+
+#### Some example
+
+```
+cat myPrivateKey
+```
+
+This command will show the content of an encrypted file, which is called `myPrivateKey`. In particular, it will show the latest version of the file.
+
+Adding options to the command, it is possible to either see a specific version or list all the versions.
+
+The versioning is very important in Secrez because the primary way to backup and distribute the data is using Git. In this case, you want to avoid conflicts that can be not fixable because of the encryption. So, every time there is a change, an entirely new file is created, with metadata about its id and timestamp.
+
+The timestamp is used to assign a version to the file. A version is a 4-letters hash of the timestamp.
+
+Another example:
+
+```
+import ~/Desktop/myWallet.json -m
+```
+
+This command takes the standard file myWallet.json, contained in the Desktop folder, encrypts it, saves it in the encrypted file system, and removes (-m) it from the original folder.
+
+This is one of my favorite commands. In fact, let's say that you have just downloaded the private key to access your crypto wallet, you want to encrypt it as soon as possible. With Secrez, you can import the file and delete the cleartext version in one command.
+
+#### Aliases — where the fun comes :-)
+
+Suppose that you have a card for your bank and like to login to your bank. You could copy email and password to the clipboard to paste them in the browser. Suppose that you expect to be able in 4 seconds to move from the terminal to the browser, you could run the command:    
+
+```
+copy bank.yml -f email password -t 4 3
+```
+This will copy the email field and give you 4 seconds to paste it in the browser. After it will emit a beep and you have 3 seconds to paste the password. It sounds quite useful, but **it can be better.**
+
+If you use that login often, you could like to create an alias for it with:
+```
+alias b -c "copy bank.yml -f email password -t 4 3"
+```
+Next time, you can just type
+```
+b
+```
+and press enter to execute that command. It's fantastic, isn't it?
+
 
 #### Importing from other password/secret managers
 
@@ -238,18 +280,17 @@ If in the CSV file there is also the field `tags`, you can tag automatically any
 
 #### Second factor authentication
 
-Secrez uses external scripts in Python, based on  Python-Fido2 by Yubiko, and it's compatible with any Fido2 authenticator device implementing the hmac-secret extension.
+Since version 0.6.1, Secrez supports 2FA. It uses external scripts in Python, based on  Python-Fido2 by Yubiko, and it's compatible with any Fido2 authenticator device implementing the hmac-secret extension.
 
 To register a new fido2 key with the name `solo`, you can call
 
 ```
 conf -r solo --fido2
 ```
-If some of the requirements are missing, you will see an error message.
 
-After activating the first fido2 key, Secrez asks if you also want to generate an emergency recovery code. It allows you to recover the account if all the registered keys are lost.
+When you activate the first fido2 key, Secrez asks if you also want to generate an emergency recovery code. It allows you to recover the account if all the registered keys are lost.
 
-You can set more than one, with a command like:
+You can set more keys and more recovery codes. For the latter, with a command like:
 
 ```
 conf -r memo --recovery-code
@@ -279,9 +320,9 @@ If solo is the only USB device you set, Secrez removes all the recovery codes an
 
 **Risks**
 
-Adding or removing a second factor changes the keys.json file. So, if you are using a git repository, be sure you don't create conflicts, i.e., don't change the second factor configuration in more computer parallely because you risk to damage your data.
+Adding or removing a second factor changes the keys.json file. So, if you are using a git repository, be sure you don't create conflicts, i.e., don't change the second factor configuration in more computer parallelly because you risk to damage your data.
 
-As a rule of thumb, if you use a git repo, always commit and push before changing the configuration.
+As a rule of thumb, if you use a git repo, always pull before running Secrez, and always commit and push after exiting.
 
 #### Some thoughts
 

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.6.1",
+	"version": "0.6.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@secrez/core": "^0.6.0",
-    "@secrez/fs": "^0.6.6",
+    "@secrez/fs": "^0.6.7",
     "beepbeep": "^1.3.0",
     "case": "^1.6.3",
     "chalk": "^3.0.0",

--- a/packages/secrez/src/AliasManager.js
+++ b/packages/secrez/src/AliasManager.js
@@ -1,0 +1,71 @@
+const {DataCache} = require('@secrez/fs')
+
+let cache = new DataCache
+
+class AliasManager {
+
+  static setCache(dataCache) {
+    if (typeof dataCache === 'object') {
+      cache = dataCache
+    }
+  }
+
+  static getCache() {
+    return cache
+  }
+
+  // list() {
+  //   return cache.list('alias')
+  // }
+  //
+  get(alias) {
+    return cache.get('alias', alias)
+  }
+
+  validateCommand(line, regularCmds) {
+    if (!line) {
+      return 'No previous command'
+    }
+    let cmd = line.split(' ')[0]
+    if (this.get(cmd)) {
+      return 'Can not make an alias of an alias'
+    }
+    if (regularCmds && !regularCmds[cmd]) {
+      return `"${cmd}" is not a valid command`
+    }
+  }
+
+  validateName(name) {
+    if (!/^(\w|-)+$/g.test(name)) {
+      return `The name "${name}" is invalid. Aliases' names can be any combination of upper and lower letters, numerals, underscores and hiphens`
+    }
+  }
+
+  async create(options) {
+    if (this.get(options.name)) {
+      throw new Error(`An alias named "${options.name}" already exists`)
+    }
+    return await cache.puts('alias', {
+      value: options.name,
+      content: options.commandLine
+    })
+  }
+
+  async remove(alias) {
+    return await cache.remove('alias', alias)
+  }
+
+  async rename(existentName, alias) {
+    let old = this.get(existentName)
+    if (await this.remove(existentName)) {
+      return await this.create({
+        name: alias,
+        commandLine: old.content
+      })
+    }
+    return false
+  }
+
+}
+
+module.exports = AliasManager

--- a/packages/secrez/src/commands/Alias.js
+++ b/packages/secrez/src/commands/Alias.js
@@ -1,0 +1,192 @@
+const chalk = require('chalk')
+const AliasManager = require('../AliasManager')
+
+class Alias extends require('../Command') {
+
+  setHelpAndCompletion() {
+    this.cliConfig.completion.alias = {
+      _func: this.pseudoFileCompletion(this),
+      _self: this
+    }
+    this.cliConfig.completion.help.alias = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      },
+      {
+        name: 'name',
+        alias: 'n',
+        defaultOption: true,
+        type: String
+      },
+      {
+        name: 'command-line',
+        alias: 'c',
+        type: String
+      },
+      {
+        name: 'list',
+        alias: 'l',
+        type: Boolean
+      },
+      {
+        name: 'filter',
+        alias: 'f',
+        type: String
+      },
+      {
+        name: 'previous-command',
+        alias: 'p',
+        type: Boolean
+      },
+      {
+        name: 'rename',
+        alias: 'r',
+        type: String,
+        multiple: true
+      },
+      {
+        name: 'delete',
+        alias: 'd',
+        type: String
+      },
+      {
+        name: 'skip-confirm',
+        type: Boolean
+      }
+    ]
+  }
+
+  help() {
+    return {
+      description: ['Create aliases of other commands.',
+        'Aliases\' name are case sensitive. They can be any combination of letters, numerals, underscores and hiphens',
+        'If an alias conflicts with a command, you can disambiguate it prefixing it with a $. Like calling the alias "mv" as "$mv".'],
+      examples: [
+        ['alias f -c "copy facebook.yml -f email password -t 4"', 'creates an alias "f" that executes "copy facebook.yml -f email password -t 4"'],
+        ['alias g --previous-command', 'creates the alias "g" using the previous command; this allows you to test something, and when ready generate an alias for it'],
+        ['alias -l', 'lists all the created aliases'],
+        ['alias -l -f copy', 'lists the aliases filtering the ones that execute a "copy" command'],
+        ['alias -r f fb', 'renames the alias "f" to "fb"'],
+        ['alias -d g', 'deletes the alias "g"']
+      ]
+    }
+  }
+
+  async alias(options) {
+    if (!AliasManager.getCache().dataPath) {
+      // for testing, when Prompt is not required
+      AliasManager.setCache(this.secrez.cache)
+    }
+    if (!this.aliasManager) {
+      this.aliasManager = new AliasManager
+    }
+    if (options.previousCommand && options.commandLine) {
+      throw new Error('Conflicting parameters')
+    }
+    if (options.name && (options.previousCommand || options.commandLine)) {
+      let error = this.aliasManager.validateName(options.name)
+      if (error) {
+        throw new Error(error)
+      }
+      if (this.aliasManager.get(options.name)) {
+        throw new Error(`An alias named "${options.name}" already exists`)
+      }
+      if (!options.commandLine) {
+        options.commandLine = // for testing
+            process.env.NODE_ENV === 'test'
+                ? options.previousCommandLine
+                : this.prompt.previousCommandLine
+      }
+      error = this.aliasManager.validateCommand(options.commandLine, this.prompt.commands)
+      if (error) {
+        throw new Error(error)
+      }
+      let yes = options.skipConfirm
+      /* istanbul ignore if  */
+      if (!yes) {
+        yes = await this.useConfirm({
+          message: `Are you sure you want to create the alias ${chalk.green(options.name)} for ${chalk.green(options.commandLine)}?`,
+          default: false
+        })
+      }
+      if (yes) {
+        if (await this.aliasManager.create(options)) {
+          return chalk.grey('The alias has been created')
+        }
+      } else {
+        return chalk.grey('Operation canceled')
+      }
+
+    } else if (options.list) {
+      let list = []
+      let aliases = this.aliasManager.get()
+      let max = 0
+      for (let alias in aliases) {
+        let content = aliases[alias].content
+        if (options.filter) {
+          if (content.split(' ')[0] !== options.filter) {
+            continue
+          }
+        }
+        list.push([alias, content])
+        max = Math.max(max, alias.length)
+      }
+      for (let i=0;i<list.length; i++) {
+        list[i] = list[i][0] + ' '.repeat(max - list[i][0].length) + '  ' + chalk.grey(list[i][1])
+      }
+      return list
+    } else if (options.rename) {
+      let [existentName, newName] = options.rename
+      if (!this.aliasManager.get(existentName)) {
+        throw new Error(`An alias named "${existentName}" does not exist`)
+      }
+      let error = this.aliasManager.validateName(newName)
+      if (error) {
+        throw new Error(error)
+      }
+      if (await this.aliasManager.rename(existentName, newName)) {
+        return chalk.grey(`The alias "${existentName}" has been renamed "${newName}"`)
+      } else {
+        throw new Error(`Could not rename "${existentName}"`)
+      }
+    } else if (options.delete) {
+      let existentName = options.delete
+      if (!this.aliasManager.get(existentName)) {
+        throw new Error(`An alias named "${existentName}" does not exist`)
+      }
+      if (await this.aliasManager.remove(existentName)) {
+        return chalk.grey(`The alias "${existentName}" has been removed`)
+      } else {
+        throw new Error(`Could not remove "${existentName}"`)
+      }
+
+    } else {
+      throw new Error('Wrong parameters')
+    }
+  }
+
+  async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
+    try {
+      let result = await this.alias(options)
+      if (!Array.isArray(result)) {
+        result = [result]
+      }
+      for (let r of result) {
+        this.Logger.reset(r)
+      }
+    } catch (e) {
+      this.Logger.red(e.message)
+    }
+    this.prompt.run()
+  }
+}
+
+module.exports = Alias
+
+

--- a/packages/secrez/src/commands/Exit.js
+++ b/packages/secrez/src/commands/Exit.js
@@ -7,6 +7,12 @@ class Exit extends require('../Command') {
       // dontSaveHistory: TRUE // not supported, yet
     })
     this.cliConfig.completion.help.exit = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      }]
   }
 
   help() {
@@ -20,6 +26,9 @@ class Exit extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     this.Logger.reset('Bye bye :o)')
     /* istanbul ignore if  */
     // eslint-disable-next-line no-constant-condition

--- a/packages/secrez/src/commands/Use.js
+++ b/packages/secrez/src/commands/Use.js
@@ -1,4 +1,3 @@
-
 class Use extends require('../Command') {
 
   setHelpAndCompletion() {
@@ -33,15 +32,15 @@ class Use extends require('../Command') {
   }
 
   completion(self) {
-      return async options => {
-        let datasetsInfo = await this.internalFs.getDatasetsInfo()
-        options.forAutoComplete = true
-        if (options.dataset) {
-          return datasetsInfo.map(e => e.name).filter(e => RegExp('^' + options.dataset).test(e))
-        } else {
-          return datasetsInfo.map(e => e.name)
-        }
+    return async options => {
+      let datasetsInfo = await this.internalFs.getDatasetsInfo()
+      options.forAutoComplete = true
+      if (options.dataset) {
+        return datasetsInfo.map(e => e.name).filter(e => RegExp('^' + options.dataset).test(e))
+      } else {
+        return datasetsInfo.map(e => e.name)
       }
+    }
   }
 
   help() {
@@ -72,20 +71,20 @@ class Use extends require('../Command') {
         throw new Error('The dataset does not exist; add "-c" to create it')
       }
       if (newSet && options.rename) {
-          if (['main', 'trash'].includes(options.dataset)) {
-            throw new Error('main and trash cannot be renamed')
+        if (['main', 'trash'].includes(options.dataset)) {
+          throw new Error('main and trash cannot be renamed')
+        }
+        let name = options.dataset
+        let newName = options.rename
+        for (let dataset of datasetsInfo) {
+          if (dataset.name === newName) {
+            throw new Error(`A dataset named ${newName} already exists`)
           }
-          let name = options.dataset
-          let newName = options.rename
-          for (let dataset of datasetsInfo) {
-            if (dataset.name === newName) {
-              throw new Error(`A dataset named ${newName} already exists`)
-            }
-          }
-          await this.internalFs.mountTree(newIndex)
-          await this.internalFs.trees[newIndex].nameDataset(newName)
-          this.internalFs.updateTreeCache(newIndex, newName)
-          return `The dataset ${name} has been renamed ${newName}`
+        }
+        await this.internalFs.mountTree(newIndex)
+        await this.internalFs.trees[newIndex].nameDataset(newName)
+        this.internalFs.updateTreeCache(newIndex, newName)
+        return `The dataset ${name} has been renamed ${newName}`
       }
       if (newSet && newSet.index === this.internalFs.treeIndex) {
         return `You are already using ${options.dataset}`
@@ -110,7 +109,7 @@ class Use extends require('../Command') {
       if (result) {
         this.Logger.reset(result)
       }
-    } catch(e) {
+    } catch (e) {
       this.Logger.red(e.message)
     }
     this.prompt.run()

--- a/packages/secrez/src/commands/Ver.js
+++ b/packages/secrez/src/commands/Ver.js
@@ -5,6 +5,12 @@ class Ver extends require('../Command') {
   setHelpAndCompletion() {
     this.cliConfig.completion.ver = {}
     this.cliConfig.completion.help.ver = true
+    this.optionDefinitions = [
+      {
+        name: 'help',
+        alias: 'h',
+        type: Boolean
+      }]
   }
 
   help() {
@@ -17,6 +23,9 @@ class Ver extends require('../Command') {
   }
 
   async exec(options = {}) {
+    if (options.help) {
+      return this.showHelp()
+    }
     this.Logger.reset(`v${pkg.version}`)
     this.prompt.run()
   }

--- a/packages/secrez/test/commands/Alias.test.js
+++ b/packages/secrez/test/commands/Alias.test.js
@@ -1,0 +1,215 @@
+const chai = require('chai')
+const assert = chai.assert
+const stdout = require('test-console').stdout
+
+const fs = require('fs-extra')
+const path = require('path')
+const Prompt = require('../mocks/PromptMock')
+const AliasManager = require('../../src/AliasManager')
+const {assertConsole, noPrint, decolorize} = require('../helpers')
+
+const {
+  password,
+  iterations
+} = require('../fixtures')
+
+// eslint-disable-next-line no-unused-vars
+const jlog = require('../helpers/jlog')
+
+describe('#Alias', function () {
+
+  let prompt
+  let testDir = path.resolve(__dirname, '../../tmp/test')
+  let rootDir = path.resolve(testDir, '.secrez')
+  let inspect, C
+
+  let options = {
+    container: rootDir,
+    localDir: __dirname
+  }
+
+  beforeEach(async function () {
+    AliasManager.getCache().reset()
+    await fs.emptyDir(testDir)
+    prompt = new Prompt
+    await prompt.init(options)
+    C = prompt.commands
+    await prompt.secrez.signup(password, iterations)
+  })
+
+  it('should return the help', async function () {
+
+    inspect = stdout.inspect()
+    await C.alias.exec({help: true})
+    inspect.restore()
+    let output = inspect.output.map(e => decolorize(e))
+    assert.isTrue(/-h, --help/.test(output[6]))
+
+  })
+
+  it('create initialize correctly the AliasManager', async function () {
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      list: true
+    })
+    inspect.restore()
+    assertConsole(inspect, [])
+
+    assert.equal(AliasManager.getCache().dataPath, path.join(rootDir, 'cache'))
+
+  })
+
+  it('create aliases and lists them', async function () {
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f',
+      skipConfirm: true,
+      commandLine: 'ls dir'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias has been created')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'r',
+      skipConfirm: true,
+      commandLine: 'rm *'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias has been created')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      list: true
+    })
+    inspect.restore()
+    assertConsole(inspect, [
+        'f  ls dir',
+        'r  rm *'
+    ])
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      list: true,
+      filter: 'ls'
+    })
+    inspect.restore()
+    assertConsole(inspect, [
+      'f  ls dir'
+    ])
+
+  })
+
+  it('rename and delete aliases', async function () {
+
+    await C.alias.exec({
+      list: true
+    })
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f',
+      skipConfirm: true,
+      commandLine: 'ls dir'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias has been created')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'r',
+      skipConfirm: true,
+      commandLine: 'rm *'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias has been created')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      delete: 'f'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias "f" has been removed')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      rename: ['r', 'R']
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The alias "r" has been renamed "R"')
+
+  })
+
+  it('should throw if there are errors', async function () {
+
+    await noPrint(C.alias.exec({
+      name: 'r',
+      skipConfirm: true,
+      commandLine: 'rm *'
+    }))
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f*',
+      skipConfirm: true,
+      commandLine: 'ls dir'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'The name "f*" is invalid. Aliases\' names can be any combination of upper and lower letters, numerals, underscores and hiphens')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f',
+      skipConfirm: true,
+      commandLine: 'bingo dir'
+    })
+    inspect.restore()
+    assertConsole(inspect, '"bingo" is not a valid command')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f',
+      skipConfirm: true,
+      commandLine: 'r'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'Can not make an alias of an alias')
+
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'f',
+      skipConfirm: true
+    })
+    inspect.restore()
+    assertConsole(inspect, 'Wrong parameters')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      name: 'r',
+      skipConfirm: true,
+      commandLine: 'rm *'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'An alias named "r" already exists')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      delete: 'ds'
+    })
+    inspect.restore()
+    assertConsole(inspect, 'An alias named "ds" does not exist')
+
+    inspect = stdout.inspect()
+    await C.alias.exec({
+      rename: ['x', 'R']
+    })
+    inspect.restore()
+    assertConsole(inspect, 'An alias named "x" does not exist')
+
+  })
+
+})
+

--- a/packages/secrez/test/utils/index.test.js
+++ b/packages/secrez/test/utils/index.test.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const assert = chai.assert
 const fs = require('fs-extra')
 const path = require('path')
-const {isYaml, yamlParse, yamlStringify, fromCsvToJson} = require('../../src/utils')
+const {isYaml, yamlParse, yamlStringify, fromCsvToJson, TRUE} = require('../../src/utils')
 
 const {yml, yml2} = require('../fixtures')
 
@@ -92,6 +92,14 @@ describe  ('#utils', function () {
       assert.equal(yamlStringify({
         pass: 'PASS'
       }), 'pass: PASS\n')
+    })
+
+  })
+
+  describe('TRUE', async function () {
+
+    it('should return true', async function () {
+      assert.equal(TRUE(), true)
     })
 
   })


### PR DESCRIPTION
Suppose that you have a card for your bank and like to login to your bank. You could copy email and password to the clipboard to paste them in the browser. Suppose that you expect to be able in 4 seconds to move from the terminal to the browser, you could run the command:    

```
copy bank.yml -f email password -d 4 3
```
This will copy the email field and give you 4 seconds to paste it in the browser. After it will emit a beep and you have 3 seconds to paste the password. It sounds quite useful, but **it can be better.**

If you use that login often, you could like to create an alias for it with:
```
alias b -c "copy bank.yml -f email password -d 4 3"
```
Next time, you can just type
```
b
```
and press enter to execute that command. It's fantastic, isn't it?

For more details launch the help
```
Secrez main:/ $ alias -h

Create aliases of other commands.
  Aliases' name are case sensitive. They can be any combination of letters, numerals, underscores and hiphens
  If an alias conflicts with a command, you can disambiguate it prefixing it with a $. Like calling the alias "mv" as "$mv".

Available options:
  -h, --help                Boolean             
  -n, --name                String    (default) 
  -c, --command-line        String              
  -l, --list                Boolean             
  -f, --filter              String              
  -p, --previous-command    Boolean             
  -r, --rename              String[]            
  -d, --delete              String              
  --skip-confirm            Boolean             
Examples:
  alias f -c "copy            
    facebook.yml -f email     
    password -t 4"            (creates an alias "f" that executes "copy
                                facebook.yml -f email password -t 4")
  alias g --previous-command  (creates the alias "g" using the previous
                                command; this allows you to test something, and
                                when ready generate an alias for it)
  alias -l                    (lists all the created aliases)
  alias -l -f copy            (lists the aliases filtering the ones that
                                execute a "copy" command)
  alias -r f fb               (renames the alias "f" to "fb")
  alias -d g                  (deletes the alias "g")

```

