### PR TITLE
Auto delete export

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.6.5__
+* add `duration` to `export` to delete the exported file after the duration (in seconds)
+
 __0.6.4__
 * add `alias` to generate alias of any command
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ b
 ```
 and press enter to execute that command. It's fantastic, isn't it?
 
+Notice that the command above works in you are using the `main` dataset, if you moved to another one, it would fail. When you create an alias, it is better to use absolute paths so that it works everywhere, like:
+```
+copy main:/bank.yml -f email password -d 4 3
+```
 
 #### Importing from other password/secret managers
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -211,6 +211,10 @@ b
 ```
 and press enter to execute that command. It's fantastic, isn't it?
 
+Notice that the command above works in you are using the `main` dataset, if you moved to another one, it would fail. When you create an alias, it is better to use absolute paths so that it works everywhere, like:
+```
+copy main:/bank.yml -f email password -d 4 3
+```
 
 #### Importing from other password/secret managers
 
@@ -335,6 +339,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 - Plugin architecture to allow others to add their own commands
 
 ### History
+
+__0.6.5__
+* add `duration` to `export` to delete the exported file after the duration (in seconds)
 
 __0.6.4__
 * add `alias` to generate alias of any command

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Lls.js
+++ b/packages/secrez/src/commands/Lls.js
@@ -57,16 +57,21 @@ class Lls extends require('../Command') {
     }
   }
 
+  async lls(options) {
+    options.returnIsDir = true
+    let [isDir, list] = await this.externalFs.fileCompletion(options)
+    if (!isDir) {
+      list = await FsUtils.filterLs(options, list)
+    }
+    return list
+  }
+
   async exec(options = {}) {
     if (options.help) {
       return this.showHelp()
     }
     try {
-      options.returnIsDir = true
-      let [isDir, list] = await this.externalFs.fileCompletion(options)
-      if (!isDir) {
-        list = await FsUtils.filterLs(options, list)
-      }
+      let list = await this.lls(options)
       if (list) {
         if (list.length) {
           this.Logger.reset(options.list

--- a/packages/secrez/test/commands/Export.test.js
+++ b/packages/secrez/test/commands/Export.test.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra')
 const path = require('path')
 
 const Prompt = require('../mocks/PromptMock')
-const {assertConsole, noPrint, decolorize} = require('../helpers')
+const {assertConsole, noPrint, decolorize, sleep} = require('../helpers')
 
 const {
   password,
@@ -78,6 +78,35 @@ describe('#Export', function () {
 
     content2 = await C.lcat.lcat({path: path.join(await C.lpwd.lpwd(), 'file.2')})
     assert.equal(content2, content)
+
+  })
+
+  it('should export a file and delete it after 1 second', async function () {
+
+    let content = 'Some secret'
+    let p = '/folder/file'
+
+    await noPrint(C.touch.exec({
+      path: p,
+      content
+    }))
+
+    await noPrint(C.cd.exec({
+      path: '/folder'
+    }))
+
+    await noPrint(C.export.exec({
+      path: 'file',
+      duration: 1
+    }))
+
+    let list = await C.lls.lls({path: await C.lpwd.lpwd()})
+    assert.equal(list.length, 1)
+
+    await sleep(1200)
+
+    list = await C.lls.lls({path: await C.lpwd.lpwd()})
+    assert.equal(list.length, 0)
 
   })
 


### PR DESCRIPTION
When exporting a file, the `duration` option allows to automatically delete the file after the seconds set with the option. Let's say you want to import a Keystore/JSON file in MyEtherWallet. You can export it with something like
```
export mew-export-2020-06-22T20_10_15.789Z.json ~/Desktop -d 30
```
knowing that after 30 seconds the file will be deleted.

It also fixes a bug in `lls`.