### PR TITLE
Version 0.7.0, new derivationVersion, changes to password and iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ secrez -si 876352
 where the `-s` option saves the number locally in a git-ignored `env.json` file. This way you don't have to retype it all the time to launch Secrez (typing a wrong number of iterations, of course, will produce an error).
 
 If you don't explicitly set up the number of iterations, a value for that is asked during the set up, before your password, and, if you passed the options `-s`, is saved in `env.json`.
-If starting your account, you put a large number and you think that it's too slow for your computer, delete the Secrez folder (by default `rm -rf ~/.secrez`) and restart.
+
+Starting from version 0.7.0, you can change the number of iterations using, as well as the password, using `conf`.
 
 Other options are:
 
@@ -340,11 +341,15 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.7.0__
+* Introduce a more secure derivation process, using the iterations number in the salt. During the upgrade existing second factors of authentication will be removed
+* Allow to change password and number of iterations in `conf`. BE CAREFUl, any change in `conf` can cause conflicts in a remote repo. Don't do the same changes parallelly
+
 __0.6.5__
-* add `duration` to `export` to delete the exported file after the duration (in seconds)
+* Add `duration` to `export` to delete the exported file after the duration (in seconds)
 
 __0.6.4__
-* add `alias` to generate alias of any command
+* Add `alias` to generate alias of any command
 
 __0.6.3__
 * Minor bug fix
@@ -355,12 +360,12 @@ __0.6.2__
 __0.6.1__
 * Add support for U2F keys (Yubikey, Solokeys, etc.)
 * `ls` now returns sorted results
-* fixed bug with `mv` and `rm` when using wildcards
-* dynamic format for help, managing large examples
+* Fixed bug with `mv` and `rm` when using wildcards
+* Dynamic format for help, managing large examples
 
 __0.6.0__
 * Allow multiple datasets; `main` and `trash` exists by default
-* at start, purges old trees after successfully loading a dataset
+* At start, purges old trees after successfully loading a dataset
 * `use` allows to use and create new dataset
 * `mv` supports `-d, --destination` for the destination
 * `mv` allows to move files among datasets with a syntax like `mv somefile archive:/` or `mv archive:somefile main:/some/`
@@ -368,8 +373,8 @@ __0.6.0__
 * `mv`, if no destination set, asks if like to use the active directory in the target dataset
 * `ls -o d` and `ls -o f` to limit the listing only to folders or files
 * `copy` allows to select the field to copy in yaml files
-* improve autocomplete to handle datasets
-* fix autocomplete in `lcat`, which was wrongly using the internal files
+* Improve autocomplete to handle datasets
+* Fix autocomplete in `lcat`, which was wrongly using the internal files
 * `tag` is able to list and show tags along all the datasets, anche can use `--find` like `mv`
 
 __0.5.13__

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/core",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@secrez/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",
     "all-tests": "find test/** -name '*.test.js' | xargs ./node_modules/.bin/mocha -R spec",
-    "test-only": "./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
+    "test-only": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
     "posttest": "nyc check-coverage --statements 99 --branches 96 --functions 100 --lines 98"
   },

--- a/packages/core/test/fixtures/index.js
+++ b/packages/core/test/fixtures/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   password: 'unaSTRANA342',
+  newPassword: 'sa7sau3h33y2hhes',
   b58Hash: 'J5JDehfYiYFyRcySdHQNiCJdVrsrUyVtpCEXU7fBQ6q3',
   passwordSHA3Hex: 'fdb07834d77b30a750f3b14ab06b000730ee2f2bb52a842fc78d72d88c82038e',
   passwordB64: 'dW5hU1RSQU5BMzQy',
@@ -8,6 +9,7 @@ module.exports = {
   iterationsB58: '7Yq',
   hash23456iterations: 'GCF7ytpi9DyMPbuDhLj6vW1oSe99nBTLzABcb1qvTeLY',
   hash23456iterationsNoSalt: 'ErQE64oXPPs7QqbirznqzCap3KNyMKDZZZBexRfhS7Pb',
+  hash23456iterationsNoSaltVersionTwo: '621vXeh5P96cRCjRvEtiquBjQ9nDv5vWqpzENyMoWia5',
   secondFactor: {
     authenticator: 'yubo',
     id: '7sheywt3rfse',

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/fs",
-	"version": "0.6.7",
+	"version": "0.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@secrez/fs",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",
     "all-tests": "find test/** -name '*.test.js' | xargs ./node_modules/.bin/mocha -R spec",
-    "test-only": "./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
+    "test-only": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
     "posttest": "nyc check-coverage --statements 85 --branches 80 --functions 85 --lines 85"
   },
   "dependencies": {
-    "@secrez/core": "^0.6.0",
+    "@secrez/core": "^0.7.0",
     "base58": "^2.0.1",
     "bs58": "^4.0.1",
     "command-line-args": "^5.1.1",

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -106,7 +106,8 @@ secrez -si 876352
 where the `-s` option saves the number locally in a git-ignored `env.json` file. This way you don't have to retype it all the time to launch Secrez (typing a wrong number of iterations, of course, will produce an error).
 
 If you don't explicitly set up the number of iterations, a value for that is asked during the set up, before your password, and, if you passed the options `-s`, is saved in `env.json`.
-If starting your account, you put a large number and you think that it's too slow for your computer, delete the Secrez folder (by default `rm -rf ~/.secrez`) and restart.
+
+Starting from version 0.7.0, you can change the number of iterations using, as well as the password, using `conf`.
 
 Other options are:
 
@@ -340,11 +341,15 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__0.7.0__
+* Introduce a more secure derivation process, using the iterations number in the salt. During the upgrade existing second factors of authentication will be removed
+* Allow to change password and number of iterations in `conf`. BE CAREFUl, any change in `conf` can cause conflicts in a remote repo. Don't do the same changes parallelly
+
 __0.6.5__
-* add `duration` to `export` to delete the exported file after the duration (in seconds)
+* Add `duration` to `export` to delete the exported file after the duration (in seconds)
 
 __0.6.4__
-* add `alias` to generate alias of any command
+* Add `alias` to generate alias of any command
 
 __0.6.3__
 * Minor bug fix
@@ -355,12 +360,12 @@ __0.6.2__
 __0.6.1__
 * Add support for U2F keys (Yubikey, Solokeys, etc.)
 * `ls` now returns sorted results
-* fixed bug with `mv` and `rm` when using wildcards
-* dynamic format for help, managing large examples
+* Fixed bug with `mv` and `rm` when using wildcards
+* Dynamic format for help, managing large examples
 
 __0.6.0__
 * Allow multiple datasets; `main` and `trash` exists by default
-* at start, purges old trees after successfully loading a dataset
+* At start, purges old trees after successfully loading a dataset
 * `use` allows to use and create new dataset
 * `mv` supports `-d, --destination` for the destination
 * `mv` allows to move files among datasets with a syntax like `mv somefile archive:/` or `mv archive:somefile main:/some/`
@@ -368,8 +373,8 @@ __0.6.0__
 * `mv`, if no destination set, asks if like to use the active directory in the target dataset
 * `ls -o d` and `ls -o f` to limit the listing only to folders or files
 * `copy` allows to select the field to copy in yaml files
-* improve autocomplete to handle datasets
-* fix autocomplete in `lcat`, which was wrongly using the internal files
+* Improve autocomplete to handle datasets
+* Fix autocomplete in `lcat`, which was wrongly using the internal files
 * `tag` is able to list and show tags along all the datasets, anche can use `--find` like `mv`
 
 __0.5.13__

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.6.4",
+	"version": "0.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -584,6 +584,44 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
 			"dev": true
 		},
+		"@secrez/core": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@secrez/core/-/core-0.6.0.tgz",
+			"integrity": "sha512-0b2ReY0fFIVksthFxBzYiOnqEyTR0E+ZZ2grypGpAPzXwK2vV1WlnY/uwSUk/Nk6zjdH3JyoDNnGWjA5fEVQpw==",
+			"requires": {
+				"base58": "^2.0.1",
+				"bip39": "^3.0.2",
+				"bs58": "^4.0.1",
+				"fs-extra": "^8.1.0",
+				"homedir": "^0.6.0",
+				"isbinaryfile": "^4.0.5",
+				"lodash": "^4.17.15",
+				"microtime": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"seedrandom": "^3.0.5",
+				"sha3": "^2.1.2",
+				"shamir": "^0.7.1",
+				"tweetnacl": "^1.0.3",
+				"tweetnacl-util": "^0.15.1"
+			}
+		},
+		"@secrez/fs": {
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/@secrez/fs/-/fs-0.6.7.tgz",
+			"integrity": "sha512-yDejW94l2cq/05YUUNdiGqcWmhXSBk/HSv3N2FcmVw9slauwM6cyOioaiI6dXJ+wFANS58c7vuNd7hzvyuCLtw==",
+			"requires": {
+				"@secrez/core": "^0.6.0",
+				"base58": "^2.0.1",
+				"bs58": "^4.0.1",
+				"command-line-args": "^5.1.1",
+				"fs-extra": "^8.1.0",
+				"homedir": "^0.6.0",
+				"isbinaryfile": "^4.0.5",
+				"lodash": "^4.17.15",
+				"pbkdf2": "^3.0.17",
+				"sha3": "^2.1.2"
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
@@ -624,6 +662,11 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
 		},
 		"acorn": {
 			"version": "7.1.1",
@@ -754,6 +797,24 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"base58": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/base58/-/base58-2.0.1.tgz",
+			"integrity": "sha512-qK6gt2fMSxN2xGOi+btI5oAnXL+vEq0AsHWHhf5jfm2hE6MwmW+2414qF96utV3Xfg3En8hEA9Q4lif4lbXcgw=="
+		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
 		"beepbeep": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/beepbeep/-/beepbeep-1.3.0.tgz",
@@ -764,6 +825,17 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
+		},
+		"bip39": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+			"integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+			"requires": {
+				"@types/node": "11.11.6",
+				"create-hash": "^1.1.0",
+				"pbkdf2": "^3.0.9",
+				"randombytes": "^2.0.1"
+			}
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -794,6 +866,23 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"buffer": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+			"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
 		},
 		"caching-transform": {
 			"version": "4.0.0",
@@ -886,6 +975,15 @@
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.2.0"
+			}
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"clean-stack": {
@@ -1011,6 +1109,31 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-env": {
@@ -1874,6 +1997,33 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				}
+			}
+		},
 		"hasha": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
@@ -1923,6 +2073,11 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1963,8 +2118,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
 			"version": "7.1.0",
@@ -2297,6 +2451,11 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 			"dev": true
+		},
+		"isbinaryfile": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
+			"integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -2640,6 +2799,25 @@
 				}
 			}
 		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"microtime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
+			"integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
+			"requires": {
+				"node-addon-api": "^1.2.0",
+				"node-gyp-build": "^3.8.0"
+			}
+		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -2812,6 +2990,11 @@
 				}
 			}
 		},
+		"node-addon-api": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -2821,6 +3004,11 @@
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
 			}
+		},
+		"node-gyp-build": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+			"integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -3161,6 +3349,18 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -3276,6 +3476,14 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"readable-stream": {
 			"version": "https://github.com/jeffbski/readable-stream/archive/v1.0.2-object-transform2-ret-self.tar.gz",
 			"integrity": "sha512-4DfqsAX+1OToUZ/uHLsC3NUHN7wCn2BNfkG/Eyr2ii4c4suSipjLFbVymS7pj49+aRcSutnK9dIuHS3X7fwApQ=="
@@ -3354,6 +3562,15 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"run-async": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
@@ -3373,13 +3590,41 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"secrez": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/secrez/-/secrez-0.6.6.tgz",
+			"integrity": "sha512-HdbHjKrMrRoqB1AtohmZB28OGl1Hv/6+BVqFcog6AKXZGcBPodVLXObVoIDzmvb7WrtO1OhaLPiMuQAIEGpRVA==",
+			"requires": {
+				"@secrez/core": "^0.6.0",
+				"@secrez/fs": "^0.6.7",
+				"beepbeep": "^1.3.0",
+				"case": "^1.6.3",
+				"chalk": "^3.0.0",
+				"clipboardy": "^2.3.0",
+				"command-line-args": "^5.1.1",
+				"csv-parse": "^4.9.0",
+				"external-editor": "^3.1.0",
+				"fs-extra": "^8.1.0",
+				"homedir": "^0.6.0",
+				"inquirer": "^7.1.0",
+				"inquirer-command-prompt": "^0.0.27",
+				"lodash": "^4.17.15",
+				"secrez": "^0.6.5",
+				"tiny-cli-editor": "^0.1.1",
+				"yaml": "^1.9.2"
+			}
+		},
+		"seedrandom": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -3391,6 +3636,28 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"sha3": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.2.tgz",
+			"integrity": "sha512-agYUtkzMsdFTQkM3ECyt6YW0552fyEb0tYZkl7olurS1Vg2Ms5+2SdF4VFPC1jnwtiXMb8b0fSyuAGZh+q2mAw==",
+			"requires": {
+				"buffer": "5.5.0"
+			}
+		},
+		"shamir": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/shamir/-/shamir-0.7.1.tgz",
+			"integrity": "sha512-pZGu0OiH6vbZOZsVRGYCNXsY6v5gvLjJHLJKrmgJYb0fKvhdnxSJu+dnRSg+NPeg9kudMPdTSqDRy0n7JRBP7w=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -3596,6 +3863,21 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				}
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3762,6 +4044,16 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
 			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 		},
+		"tweetnacl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+		},
+		"tweetnacl-util": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+			"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+		},
 		"type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -3815,6 +4107,11 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "3.4.0",

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -20,8 +20,8 @@
     ]
   },
   "dependencies": {
-    "@secrez/core": "^0.6.0",
-    "@secrez/fs": "^0.6.7",
+    "@secrez/core": "^0.7.0",
+    "@secrez/fs": "^0.7.0",
     "beepbeep": "^1.3.0",
     "case": "^1.6.3",
     "chalk": "^3.0.0",
@@ -34,6 +34,7 @@
     "inquirer": "^7.1.0",
     "inquirer-command-prompt": "^0.0.27",
     "lodash": "^4.17.15",
+    "secrez": "^0.6.5",
     "tiny-cli-editor": "^0.1.1",
     "yaml": "^1.9.2"
   },

--- a/packages/secrez/src/PreCommand.js
+++ b/packages/secrez/src/PreCommand.js
@@ -1,6 +1,7 @@
 const {chalk} = require('./utils/Logger')
 const {Crypto} = require('@secrez/core')
 
+
 class PreCommand {
 
   async useEditor(options) {
@@ -77,22 +78,20 @@ class PreCommand {
         default: options.content,
         validate: val => {
           if (val) {
-            if (options.validate) {
-              if (options.validate(val)) {
-                return chalk.red(options.onValidate)
-              }
-            } else {
+            if (val === exitCode) {
+              return true
+            } else if (options.validate) {
+              return options.validate(val, exitCode)
+            } else if (val.length) {
               return true
             }
           }
-          return chalk.grey(`Please, type the ${options.name}, or cancel typing ${exitCode}`)
+          return chalk.grey(`Please, type the ${options.name}, or cancel typing ${chalk.bold(exitCode)}`)
         }
       }
     ])
     if (result !== exitCode) {
       return result
-    } else {
-      return options.content
     }
   }
 

--- a/packages/secrez/src/Welcome.js
+++ b/packages/secrez/src/Welcome.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const inquirer = require('inquirer')
 const fs = require('fs-extra')
 const cliConfig = require('./cliConfig')
@@ -131,9 +132,14 @@ class Welcome {
             }
             secret = p.recoveryCode
           }
-          await secrez.sharedSignin(authenticator, secret)
+          let resCode = await secrez.sharedSignin(authenticator, secret)
           if (secrez.masterKeyHash) {
             await this.saveIterations(secrez)
+          }
+          if (resCode === 1) {
+            Logger.bold(chalk.red('Your data has been upgraded.'))
+            Logger.red('To avoid conflicts, any registered second factor has been removed.')
+            Logger.grey('Please, register them again, thanks.')
           }
           return
         } catch (e) {

--- a/packages/secrez/test/fixtures/c.yaml
+++ b/packages/secrez/test/fixtures/c.yaml
@@ -1,0 +1,4 @@
+card: cerebrale
+pin: "1234"
+pass: sdasdaewrwrwe
+note: sadewwef erg3r23or4i24923r 2er23-eq


### PR DESCRIPTION
This version introduces a better way of iterating, adding the number of iterations to the salt used during the `pbkdf2` derivation. It was supposed to be this way, but for some reason I didn't implement it in the first. Just recently, I noticed that I did a partial implementation and, with this PR, I fixed it.
To do it, I had to allow the upgrade of the account. When that was possible, allowing to change the password and the number of iterations was quite easy. So, in this PR you find that.

Before any upgrade, please, if you use any versioning system, like a Git repo, commit and push. It is always possible that there is a bug and you account become unaccessible.
