### PR TITLE
Fix a crash with edit and add confirm to definite rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__7.0.6__
+* `rm` ask confirmation before delete forever from the `trash` dataset
+* `edit` does not crash if no path is passed
+
 __7.0.5__
 * `totp` can read an image to scan a qrcode and recover its secret
 * on MacOs, `totp` can also read the image from the clipboard to recover its secret; it requires `pngpaste`
@@ -455,22 +459,22 @@ Versions < 0.5.0 are deprecated because the format was sligtly different and the
 #### Test coverage
 
 ```
-  129 passing (8s)
+  129 passing (9s)
 
 ------------------|---------|----------|---------|---------|---------------------------------
 File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s               
 ------------------|---------|----------|---------|---------|---------------------------------
-All files         |    95.5 |    82.35 |   98.91 |   95.42 |                                 
- src              |     100 |     87.5 |     100 |     100 |                                 
+All files         |   95.46 |    82.34 |   98.91 |   95.37 |                                 
+ src              |     100 |    90.63 |     100 |     100 |                                 
   AliasManager.js |     100 |    85.71 |     100 |     100 | 8,58                            
-  Command.js      |     100 |       90 |     100 |     100 | 48                              
+  Command.js      |     100 |    94.44 |     100 |     100 | 48                              
   cliConfig.js    |     100 |      100 |     100 |     100 |                                 
- src/commands     |   95.09 |    82.45 |   98.64 |      95 |                                 
+ src/commands     |   95.02 |    82.23 |   98.64 |   94.93 |                                 
   Alias.js        |   91.89 |    79.25 |     100 |   91.78 | 88,99,121,149,154,164           
   Bash.js         |   93.33 |    66.67 |     100 |   93.33 | 48                              
   Cat.js          |   98.89 |    88.89 |     100 |   98.89 | 142                             
   Cd.js           |   96.43 |    86.67 |     100 |   96.43 | 44                              
-  Copy.js         |   96.15 |       78 |     100 |    96.1 | 96,141,158                      
+  Copy.js         |   94.87 |       76 |     100 |   94.81 | 96,141,158,183                  
   Exit.js         |      90 |       50 |     100 |      90 | 30                              
   Export.js       |     100 |    64.29 |     100 |     100 | 55,75,87-92,99                  
   Find.js         |   92.54 |    86.67 |     100 |   92.31 | 90,141,172-176,182              
@@ -482,12 +486,12 @@ All files         |    95.5 |    82.35 |   98.91 |   95.42 |
   Lpwd.js         |   92.31 |      100 |     100 |   92.31 | 38                              
   Ls.js           |   88.89 |    68.75 |     100 |    87.5 | 65,69,90                        
   Mkdir.js        |     100 |    66.67 |     100 |     100 | 38-44                           
-  Mv.js           |   90.91 |       78 |     100 |    90.7 | 103,126,137-143                 
+  Mv.js           |   91.01 |    77.36 |     100 |    90.8 | 113,136,147-153                 
   Paste.js        |    90.7 |       75 |     100 |    90.7 | 65,69,77,114                    
   Pwd.js          |   92.31 |      100 |     100 |   92.31 | 36                              
   Rm.js           |   96.67 |       90 |     100 |   96.55 | 75                              
   Tag.js          |      99 |    93.75 |     100 |   98.95 | 160                             
-  Totp.js         |   97.33 |    79.49 |      80 |   97.33 | 63-82                           
+  Totp.js         |   97.33 |    79.49 |      80 |   97.33 | 67-86                           
   Touch.js        |     100 |    71.43 |     100 |     100 | 56,67                           
   Use.js          |   98.08 |     93.1 |     100 |   97.96 | 105                             
   Ver.js          |      90 |    66.67 |     100 |      90 | 27                              

--- a/bin/realign-versions.js
+++ b/bin/realign-versions.js
@@ -8,12 +8,10 @@ const pkgc = require(pc)
 const pkgf = require(pf)
 const pkgs = require(ps)
 
-const branch=execSync('git rev-parse --abbrev-ref HEAD').toString().replace(/(v|\n)/g, '')
-
 let packages = {}
-let gitDiff = execSync(`git diff master..$BRANCH --name-only`).toString().split('\n').map(e => {
+let gitDiff = execSync(`git diff master --name-only`).toString().split('\n').map(e => {
   let m = e.split('/')
-  if (m[0] === 'packages') {
+  if (m[0] === 'packages' && m[2] !== 'README.md') {
     packages[m[1]] = true
   }
   return e

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,7 +10,7 @@ A documentation will come soon. For now, for info, look at https://github.com/se
 #### Test coverage
 
 ```
-  105 passing (2s)
+  105 passing (3s)
 
 -----------------|---------|----------|---------|---------|-------------------
 File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 

--- a/packages/fs/package-lock.json
+++ b/packages/fs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@secrez/fs",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/fs",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -343,6 +343,10 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ### History
 
+__7.0.6__
+* `rm` ask confirmation before delete forever from the `trash` dataset
+* `edit` does not crash if no path is passed
+
 __7.0.5__
 * `totp` can read an image to scan a qrcode and recover its secret
 * on MacOs, `totp` can also read the image from the clipboard to recover its secret; it requires `pngpaste`
@@ -455,22 +459,22 @@ Versions < 0.5.0 are deprecated because the format was sligtly different and the
 #### Test coverage
 
 ```
-  129 passing (8s)
+  129 passing (9s)
 
 ------------------|---------|----------|---------|---------|---------------------------------
 File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s               
 ------------------|---------|----------|---------|---------|---------------------------------
-All files         |    95.5 |    82.35 |   98.91 |   95.42 |                                 
- src              |     100 |     87.5 |     100 |     100 |                                 
+All files         |   95.46 |    82.34 |   98.91 |   95.37 |                                 
+ src              |     100 |    90.63 |     100 |     100 |                                 
   AliasManager.js |     100 |    85.71 |     100 |     100 | 8,58                            
-  Command.js      |     100 |       90 |     100 |     100 | 48                              
+  Command.js      |     100 |    94.44 |     100 |     100 | 48                              
   cliConfig.js    |     100 |      100 |     100 |     100 |                                 
- src/commands     |   95.09 |    82.45 |   98.64 |      95 |                                 
+ src/commands     |   95.02 |    82.23 |   98.64 |   94.93 |                                 
   Alias.js        |   91.89 |    79.25 |     100 |   91.78 | 88,99,121,149,154,164           
   Bash.js         |   93.33 |    66.67 |     100 |   93.33 | 48                              
   Cat.js          |   98.89 |    88.89 |     100 |   98.89 | 142                             
   Cd.js           |   96.43 |    86.67 |     100 |   96.43 | 44                              
-  Copy.js         |   96.15 |       78 |     100 |    96.1 | 96,141,158                      
+  Copy.js         |   94.87 |       76 |     100 |   94.81 | 96,141,158,183                  
   Exit.js         |      90 |       50 |     100 |      90 | 30                              
   Export.js       |     100 |    64.29 |     100 |     100 | 55,75,87-92,99                  
   Find.js         |   92.54 |    86.67 |     100 |   92.31 | 90,141,172-176,182              
@@ -482,12 +486,12 @@ All files         |    95.5 |    82.35 |   98.91 |   95.42 |
   Lpwd.js         |   92.31 |      100 |     100 |   92.31 | 38                              
   Ls.js           |   88.89 |    68.75 |     100 |    87.5 | 65,69,90                        
   Mkdir.js        |     100 |    66.67 |     100 |     100 | 38-44                           
-  Mv.js           |   90.91 |       78 |     100 |    90.7 | 103,126,137-143                 
+  Mv.js           |   91.01 |    77.36 |     100 |    90.8 | 113,136,147-153                 
   Paste.js        |    90.7 |       75 |     100 |    90.7 | 65,69,77,114                    
   Pwd.js          |   92.31 |      100 |     100 |   92.31 | 36                              
   Rm.js           |   96.67 |       90 |     100 |   96.55 | 75                              
   Tag.js          |      99 |    93.75 |     100 |   98.95 | 160                             
-  Totp.js         |   97.33 |    79.49 |      80 |   97.33 | 63-82                           
+  Totp.js         |   97.33 |    79.49 |      80 |   97.33 | 67-86                           
   Touch.js        |     100 |    71.43 |     100 |     100 | 56,67                           
   Use.js          |   98.08 |     93.1 |     100 |   97.96 | 105                             
   Ver.js          |      90 |    66.67 |     100 |      90 | 27                              

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.7.5",
+	"version": "0.7.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "scripts": {
     "dev": "node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@secrez/core": "^0.7.0",
-    "@secrez/fs": "0.7.3",
+    "@secrez/fs": "0.7.4",
     "beepbeep": "^1.3.0",
     "case": "^1.6.3",
     "chalk": "^3.0.0",

--- a/packages/secrez/src/Command.js
+++ b/packages/secrez/src/Command.js
@@ -54,9 +54,21 @@ class Command extends PreCommand {
     }
   }
 
-  validate(options) {
+  validate(options, mandatoryOptions) {
     if (options._unknown) {
       throw new Error(`Unknown option: ${options._unknown} `+ chalk.grey(`(run "${this.constructor.name.toLowerCase()} -h" for help)`))
+    }
+    if (mandatoryOptions) {
+      let err = ''
+      let prefix = 'Missing options: '
+      for (let o in mandatoryOptions) {
+        if (!options[o]) {
+          err += (err ? ', ' : '') + o
+        }
+      }
+      if (err) {
+        throw new Error(prefix + err)
+      }
     }
   }
 

--- a/packages/secrez/src/commands/Cat.js
+++ b/packages/secrez/src/commands/Cat.js
@@ -174,7 +174,9 @@ class Cat extends require('../Command') {
       return this.showHelp()
     }
     try {
-      this.validate(options)
+      this.validate(options, {
+        path: true
+      })
       let fn = path.basename(options.path)
       let data = await this.cat(options)
       let extra = options.all || options.metadata || options.versions

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -151,7 +151,9 @@ class Edit extends require('../Command') {
     }
     let currentEditor
     try {
-      this.validate(options)
+      this.validate(options, {
+        path: true
+      })
       currentEditor = process.env.EDITOR
       if (options.internal) {
         process.env.EDITOR = this.getTinyCliEditorBinPath()

--- a/packages/secrez/src/commands/Mv.js
+++ b/packages/secrez/src/commands/Mv.js
@@ -72,6 +72,16 @@ class Mv extends require('../Command') {
     let dataTo = await this.internalFs.getTreeIndexAndPath(options.newPath)
     if (dataFrom.index !== dataTo.index) {
       await this.internalFs.mountTree(dataTo.index)
+    } else
+        /* istanbul ignore if  */
+    if (dataFrom.index === 1 && options.removing) {
+      let yes = await this.useConfirm({
+        message: 'Are you sure you want to definitely remove those file from Secrez?',
+        default: false
+      })
+      if (!yes) {
+        throw new Error('Operation canceled')
+      }
     }
     if (nodes) {
       this.internalFs.trees[dataFrom.index].disableSave()

--- a/packages/secrez/src/commands/Totp.js
+++ b/packages/secrez/src/commands/Totp.js
@@ -32,6 +32,10 @@ class Totp extends require('../Command') {
         type: Number
       },
       {
+        name: 'no-beep',
+        type: Boolean
+      },
+      {
         name: 'from-clipboard',
         alias: 'c',
         type: Boolean
@@ -173,7 +177,8 @@ class Totp extends require('../Command') {
               const token = authenticator.generate(totp)
               this.prompt.commands.copy.copy({
                 thisString: token,
-                duration: [options.duration || 5]
+                duration: [options.duration || 5],
+                noBeep: options.noBeep
               })
               return token
             }

--- a/packages/secrez/test/Command.test.js
+++ b/packages/secrez/test/Command.test.js
@@ -100,6 +100,19 @@ describe('#Command', function () {
       }
 
       assert.equal(command.validate(options), undefined)
+      assert.equal(command.validate(options,{
+        path: true
+      }), undefined)
+
+      try {
+        command.validate(options, {
+          file: true,
+          destination: true
+        })
+        assert.isTrue(false)
+      } catch(e) {
+        assert.equal(decolorize(e.message), 'Missing options: file, destination')
+      }
 
       options._unknown = '-w'
 
@@ -109,6 +122,7 @@ describe('#Command', function () {
       } catch(e) {
         assert.equal(decolorize(e.message), `Unknown option: ${options._unknown} (run "command -h" for help)`)
       }
+
     })
 
   })

--- a/packages/secrez/test/commands/Copy.test.js
+++ b/packages/secrez/test/commands/Copy.test.js
@@ -65,7 +65,8 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       path: 'file',
-      duration: [0.2]
+      duration: [0.2],
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Copied to clipboard:', 'file'])
@@ -83,7 +84,8 @@ describe('#Copy', function () {
     inspect = stdout.inspect()
     await C.copy.exec({
       thisString: 'caruso',
-      duration: [0.2]
+      duration: [0.2],
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Copied to clipboard:', '"caruso"'])
@@ -111,7 +113,8 @@ describe('#Copy', function () {
     await C.copy.exec({
       path: p,
       duration: [1],
-      json: true
+      json: true,
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
@@ -125,7 +128,8 @@ describe('#Copy', function () {
     await C.copy.exec({
       path: p,
       duration: [0.2],
-      field: ['password']
+      field: ['password'],
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Copied to clipboard:', 'card.yml'])
@@ -154,7 +158,8 @@ describe('#Copy', function () {
     await C.copy.exec({
       path: p,
       durationInMillis: [10],
-      field: ['none']
+      field: ['none'],
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Field "none" not found in "card.yml"'])
@@ -168,7 +173,8 @@ describe('#Copy', function () {
     await C.copy.exec({
       path: p,
       duration: [1],
-      field: ['password']
+      field: ['password'],
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['The yml is malformed. To copy the entire content, do not use the options -j or -f'])
@@ -185,14 +191,16 @@ describe('#Copy', function () {
 
     inspect = stdout.inspect()
     await C.copy.exec({
-      path: '/folder'
+      path: '/folder',
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Cannot copy a folder'])
 
     inspect = stdout.inspect()
     await C.copy.exec({
-      path: '/some'
+      path: '/some',
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['Path does not exist'])
@@ -221,7 +229,8 @@ describe('#Copy', function () {
 
     inspect = stdout.inspect()
     await C.copy.exec({
-      path: 'file1.tar.gz'
+      path: 'file1.tar.gz',
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, ['You can copy to clipboard only text files.'])

--- a/packages/secrez/test/commands/Totp.test.js
+++ b/packages/secrez/test/commands/Totp.test.js
@@ -61,7 +61,8 @@ describe('#Totp', function () {
     inspect = stdout.inspect()
     await C.totp.exec({
       path: 'card.yml',
-      duration: [0.2]
+      duration: [0.2],
+      noBeep: true
     })
     inspect.restore()
     let output = inspect.output.map(e => decolorize(e))
@@ -88,7 +89,8 @@ describe('#Totp', function () {
     inspect = stdout.inspect()
     await C.totp.exec({
       path: p,
-      fromImage: path.resolve(__dirname, '../fixtures/qrcode.png')
+      fromImage: path.resolve(__dirname, '../fixtures/qrcode.png'),
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, [
@@ -102,7 +104,8 @@ describe('#Totp', function () {
 
     inspect = stdout.inspect()
     await C.totp.exec({
-      fromImage: path.resolve(__dirname, '../fixtures/qrcode.png')
+      fromImage: path.resolve(__dirname, '../fixtures/qrcode.png'),
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, [
@@ -122,7 +125,8 @@ describe('#Totp', function () {
     inspect = stdout.inspect()
     await C.totp.exec({
       path: p,
-      fromImage: path.resolve(__dirname, '../fixtures/some.csv')
+      fromImage: path.resolve(__dirname, '../fixtures/some.csv'),
+      noBeep: true
     })
     inspect.restore()
     assertConsole(inspect, [


### PR DESCRIPTION
Add a confirm before deleting something forever.
Fixes a crash with `edit` when no path option is passed.