### PR TITLE
Fix chained aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ logs
 
 .nyc_output
 report.20*
+
+build

--- a/README.md
+++ b/README.md
@@ -365,7 +365,13 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 - More commands, included a Git command to manage the repo
 - Plugin architecture to allow others to add their own commands
 
-# History
+## History
+
+__7.0.14__
+* fix chained aliases generating prompt duplications
+
+__7.0.13__
+* fix autocomplete when single command
 
 __7.0.12__
 * adds support for Linux to `totp --from-clipboard`, using `xclip`
@@ -501,6 +507,8 @@ Versions < 0.5.0 are deprecated because the format was sligtly different and the
 
 Firs off, take a look at Secrez's [Code of conduct](https://github.com/secrez/secrez/blob/master/CODE_OF_CONDUCT.md)
 
+Second, join the brand-new [Secrez's Discord group](https://discord.gg/whsgXj) 
+
 #### Fork this repo
 
 #### Clone it
@@ -576,17 +584,17 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  129 passing (8s)
+  130 passing (9s)
 
 ------------------|---------|----------|---------|---------|---------------------------------
 File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s               
 ------------------|---------|----------|---------|---------|---------------------------------
-All files         |   95.27 |    82.26 |   98.89 |   95.18 |                                 
+All files         |   95.42 |    82.26 |     100 |   95.33 |                                 
  src              |     100 |    92.11 |     100 |     100 |                                 
   AliasManager.js |     100 |    85.71 |     100 |     100 | 8,58                            
   Command.js      |     100 |    95.83 |     100 |     100 | 55                              
   cliConfig.js    |     100 |      100 |     100 |     100 |                                 
- src/commands     |   94.81 |    81.99 |   98.63 |   94.72 |                                 
+ src/commands     |   94.97 |    81.99 |     100 |   94.88 |                                 
   Alias.js        |   91.89 |    79.25 |     100 |   91.78 | 89,100,122,150,155,165          
   Bash.js         |   93.33 |    66.67 |     100 |   93.33 | 48                              
   Cat.js          |   98.89 |    88.89 |     100 |   98.89 | 142                             
@@ -608,7 +616,7 @@ All files         |   95.27 |    82.26 |   98.89 |   95.18 |
   Pwd.js          |   92.31 |      100 |     100 |   92.31 | 36                              
   Rm.js           |   96.67 |       90 |     100 |   96.55 | 75                              
   Tag.js          |      99 |    93.75 |     100 |   98.95 | 160                             
-  Totp.js         |   97.37 |    79.49 |      80 |   97.37 | 68-90                           
+  Totp.js         |     100 |    79.49 |     100 |     100 | 68-90,140,169-174,198-210,221   
   Touch.js        |     100 |    71.43 |     100 |     100 | 56,67                           
   Use.js          |   98.04 |     93.1 |     100 |   97.92 | 103                             
   Ver.js          |      90 |    66.67 |     100 |      90 | 27                              

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -365,7 +365,13 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 - More commands, included a Git command to manage the repo
 - Plugin architecture to allow others to add their own commands
 
-# History
+## History
+
+__7.0.14__
+* fix chained aliases generating prompt duplications
+
+__7.0.13__
+* fix autocomplete when single command
 
 __7.0.12__
 * adds support for Linux to `totp --from-clipboard`, using `xclip`
@@ -501,6 +507,8 @@ Versions < 0.5.0 are deprecated because the format was sligtly different and the
 
 Firs off, take a look at Secrez's [Code of conduct](https://github.com/secrez/secrez/blob/master/CODE_OF_CONDUCT.md)
 
+Second, join the brand-new [Secrez's Discord group](https://discord.gg/whsgXj) 
+
 #### Fork this repo
 
 #### Clone it
@@ -576,17 +584,17 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  129 passing (8s)
+  130 passing (9s)
 
 ------------------|---------|----------|---------|---------|---------------------------------
 File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s               
 ------------------|---------|----------|---------|---------|---------------------------------
-All files         |   95.27 |    82.26 |   98.89 |   95.18 |                                 
+All files         |   95.42 |    82.26 |     100 |   95.33 |                                 
  src              |     100 |    92.11 |     100 |     100 |                                 
   AliasManager.js |     100 |    85.71 |     100 |     100 | 8,58                            
   Command.js      |     100 |    95.83 |     100 |     100 | 55                              
   cliConfig.js    |     100 |      100 |     100 |     100 |                                 
- src/commands     |   94.81 |    81.99 |   98.63 |   94.72 |                                 
+ src/commands     |   94.97 |    81.99 |     100 |   94.88 |                                 
   Alias.js        |   91.89 |    79.25 |     100 |   91.78 | 89,100,122,150,155,165          
   Bash.js         |   93.33 |    66.67 |     100 |   93.33 | 48                              
   Cat.js          |   98.89 |    88.89 |     100 |   98.89 | 142                             
@@ -608,7 +616,7 @@ All files         |   95.27 |    82.26 |   98.89 |   95.18 |
   Pwd.js          |   92.31 |      100 |     100 |   92.31 | 36                              
   Rm.js           |   96.67 |       90 |     100 |   96.55 | 75                              
   Tag.js          |      99 |    93.75 |     100 |   98.95 | 160                             
-  Totp.js         |   97.37 |    79.49 |      80 |   97.37 | 68-90                           
+  Totp.js         |     100 |    79.49 |     100 |     100 | 68-90,140,169-174,198-210,221   
   Touch.js        |     100 |    71.43 |     100 |     100 | 56,67                           
   Use.js          |   98.04 |     93.1 |     100 |   97.92 | 103                             
   Ver.js          |      90 |    66.67 |     100 |      90 | 27                              

--- a/packages/secrez/package-lock.json
+++ b/packages/secrez/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "secrez",
-	"version": "0.7.13",
+	"version": "0.7.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,13 +1,14 @@
 {
   "name": "secrez",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev node src -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
     "lint": "eslint -c .eslintrc 'src/**/*.js' 'test/**/*.js'",
     "test-only": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/*.test.js test/**/*.test.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js test/**/*.test.js --exit",
-    "posttest": "nyc check-coverage --statements 95 --branches 75 --functions 95 --lines 95"
+    "posttest": "nyc check-coverage --statements 95 --branches 75 --functions 95 --lines 95",
+    "build-helpers": "cd test/helpers/os && ./build.sh"
   },
   "nyc": {
     "include": "src",

--- a/packages/secrez/src/Prompt.js
+++ b/packages/secrez/src/Prompt.js
@@ -247,6 +247,9 @@ class Prompt {
               Logger.green('>>  ' + chalk.bold.grey(c))
               this.disableRun = i !== cmds.length - 1
               await this.exec([c])
+              if (i === cmds.length - 1) {
+                return
+              }
             }
           }
           if (missing) {

--- a/packages/secrez/test/commands/Totp.test.js
+++ b/packages/secrez/test/commands/Totp.test.js
@@ -3,11 +3,12 @@ const assert = chai.assert
 const stdout = require('test-console').stdout
 const clipboardy = require('clipboardy')
 const fs = require('fs-extra')
+const chalk = require('chalk')
 const path = require('path')
 const {yamlParse} = require('../../src/utils')
 
 const Prompt = require('../mocks/PromptMock')
-const {sleep, noPrint, decolorize, assertConsole} = require('../helpers')
+const {sleep, noPrint, decolorize, assertConsole, copyImageToClipboard} = require('../helpers')
 
 const {
   password,
@@ -194,6 +195,27 @@ describe('#Totp', function () {
       'The yml is malformed'
     ])
   })
+
+  it('should read a totp secret from the clipboard', async function () {
+    try {
+      await copyImageToClipboard(path.resolve(__dirname, '../fixtures/qrcode.png'))
+      inspect = stdout.inspect()
+      await C.totp.exec({
+        fromClipboard: true,
+        noBeep: true
+      })
+      inspect.restore()
+      assertConsole(inspect, [
+        'The secret in the QR Code is "ueiwureiruee"'
+      ])
+    } catch(e) {
+      console.info(chalk.bold.red(e.message))
+      assert.isTrue(false)
+    }
+
+  })
+
+
 
 })
 

--- a/packages/secrez/test/helpers/os/build.sh
+++ b/packages/secrez/test/helpers/os/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+
+  INSTALLED=$(which xclip)
+  if [[ "$INSTALLED" == "" ]]; then
+    echo "Please install xclip. On Debian/Ubuntu use 'sudo apt install xclip'"
+  fi
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+
+  gcc -Wall -g -O3 -ObjC -framework Foundation -framework AppKit -o build/impbcopy impbcopy.m
+
+fi

--- a/packages/secrez/test/helpers/os/impbcopy.m
+++ b/packages/secrez/test/helpers/os/impbcopy.m
@@ -1,0 +1,45 @@
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <unistd.h>
+BOOL copy_to_clipboard(NSString *path)
+{
+  // http://stackoverflow.com/questions/2681630/how-to-read-png-image-to-nsimage
+  NSImage * image;
+  if([path isEqualToString:@"-"])
+  {
+    // http://caiustheory.com/read-standard-input-using-objective-c
+    NSFileHandle *input = [NSFileHandle fileHandleWithStandardInput];
+    image = [[NSImage alloc] initWithData:[input readDataToEndOfFile]];
+  }else
+  {
+    image =  [[NSImage alloc] initWithContentsOfFile:path];
+  }
+  // http://stackoverflow.com/a/18124824/148668
+  BOOL copied = false;
+  if (image != nil)
+  {
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    NSArray *copiedObjects = [NSArray arrayWithObject:image];
+    copied = [pasteboard writeObjects:copiedObjects];
+    [pasteboard release];
+  }
+  [image release];
+  return copied;
+}
+
+int main(int argc, char * const argv[])
+{
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  if(argc<2)
+  {
+    printf("Usage:\n\n"
+      "Copy file to clipboard:\n    ./impbcopy path/to/file\n\n"
+      "Copy stdin to clipboard:\n    cat /path/to/file | ./impbcopy -");
+    return EXIT_FAILURE;
+  }
+  NSString *path= [NSString stringWithUTF8String:argv[1]];
+  BOOL success = copy_to_clipboard(path);
+  [pool release];
+  return (success?EXIT_SUCCESS:EXIT_FAILURE);
+}


### PR DESCRIPTION
Fix chained aliases causing duplications of the prompt.
Also, adds testing for `totp --from-clipboard`.