### PR TITLE
Bin fix

### DIFF
--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -6,9 +6,7 @@ let changes
 
 let gitDiff = execSync('git diff --name-only').toString().split('\n')
 
-console.log(gitDiff)
-
-if (gitDiff.length > 0) {
+if (gitDiff.length > 0 && gitDiff[0]) {
   console.error('The repo is not committed.')
   process.exit(1)
 }

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -17,13 +17,13 @@ function checkAndPublish(dir) {
 
 checkAndPublish('utils', '@secrez')
 checkAndPublish('test-helpers', '@secrez')
-checkAndPublish('core', '@secrez')
-checkAndPublish('courier', '@secrez')
-checkAndPublish('fs', '@secrez')
-checkAndPublish('hub', '@secrez')
-checkAndPublish('tls', '@secrez')
-checkAndPublish('tunnel', '@secrez')
-checkAndPublish('secrez')
+// checkAndPublish('core', '@secrez')
+// checkAndPublish('courier', '@secrez')
+// checkAndPublish('fs', '@secrez')
+// checkAndPublish('hub', '@secrez')
+// checkAndPublish('tls', '@secrez')
+// checkAndPublish('tunnel', '@secrez')
+// checkAndPublish('secrez')
 
 if (!changes) {
   console.log('No upgrade needed.')

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -5,6 +5,9 @@ const {execSync} = require('child_process')
 let changes
 
 let gitDiff = execSync('git diff --name-only').toString().split('\n')
+
+console.log(gitDiff)
+
 if (gitDiff.length > 0) {
   console.error('The repo is not committed.')
   process.exit(1)

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -13,6 +13,7 @@ if (gitDiff.length > 0 && gitDiff[0]) {
 
 function checkAndPublish(dir) {
   const pkg = dir === 'secrez' ? '' : '@secrez/'
+  console.log(`Checking  ${pkg}${dir}...`)
   const version = require(`../packages/${dir}/package.json`).version
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -4,6 +4,12 @@ const {execSync} = require('child_process')
 
 let changes
 
+let gitDiff = execSync('git diff --name-only').toString().split('\n')
+if (gitDiff.length > 0) {
+  console.error('The repo is not committed.')
+  process.exit(1)
+}
+
 function checkAndPublish(dir) {
   const pkg = dir === 'secrez' ? '' : '@secrez/'
   const version = require(`../packages/${dir}/package.json`).version

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -17,13 +17,13 @@ function checkAndPublish(dir) {
 
 checkAndPublish('utils', '@secrez')
 checkAndPublish('test-helpers', '@secrez')
-// checkAndPublish('core', '@secrez')
-// checkAndPublish('courier', '@secrez')
-// checkAndPublish('fs', '@secrez')
-// checkAndPublish('hub', '@secrez')
-// checkAndPublish('tls', '@secrez')
-// checkAndPublish('tunnel', '@secrez')
-// checkAndPublish('secrez')
+checkAndPublish('core', '@secrez')
+checkAndPublish('courier', '@secrez')
+checkAndPublish('fs', '@secrez')
+checkAndPublish('hub', '@secrez')
+checkAndPublish('tls', '@secrez')
+checkAndPublish('tunnel', '@secrez')
+checkAndPublish('secrez')
 
 if (!changes) {
   console.log('No upgrade needed.')

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -13,7 +13,7 @@ if (gitDiff.length > 0 && gitDiff[0]) {
 
 function checkAndPublish(dir) {
   const pkg = dir === 'secrez' ? '' : '@secrez/'
-  console.log(`Checking  ${pkg}${dir}...`)
+  console.log(`Checking  ${pkg}${dir}`)
   const version = require(`../packages/${dir}/package.json`).version
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {


### PR DESCRIPTION
Fixing `bin/publish-changed-packages.js` to return an error if the repo is not committed.