### PR TITLE
Adding onBeforeRewrite to remove #\d from find results

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.8.6__
+* Uses new onBeforeRewrite in [inquirer-command-prompt](https://github.com/sullof/inquirer-command-prompt) to remove the `#\d` when autocompleting the result of a search
+
 __0.8.5__
 * Fix issue with find results when they include datasets.
 * Improve scripts (getting coverage only for modified packages)

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -396,6 +396,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.8.6__
+* Uses new onBeforeRewrite in [inquirer-command-prompt](https://github.com/sullof/inquirer-command-prompt) to remove the `#\d` when autocompleting the result of a search
+
 __0.8.5__
 * Fix issue with find results when they include datasets.
 * Improve scripts (getting coverage only for modified packages)

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -28,7 +28,7 @@
     "fs-extra": "^8.1.0",
     "homedir": "^0.6.0",
     "inquirer": "^7.1.0",
-    "inquirer-command-prompt": "^0.0.29",
+    "inquirer-command-prompt": "^0.0.32",
     "jimp": "^0.13.0",
     "lodash": "^4.17.15",
     "otplib": "^12.0.1",

--- a/packages/secrez/src/prompts/CommandPrompt.js
+++ b/packages/secrez/src/prompts/CommandPrompt.js
@@ -212,6 +212,13 @@ class CommandPrompt {
     return 'grey'
   }
 
+  onBeforeRewrite(line) {
+    if (/ #\d+(\w+:|)\/[\w/]+/.test(line)) {
+      line = line.replace(/ #\d+((\w+:|)\/[\w/]+)/,' $1')
+    }
+    return line
+  }
+
   async run(options = {}) {
     await this.firstRun()
     await this.preRun(options)
@@ -233,6 +240,7 @@ class CommandPrompt {
           ellipsize: true,
           autocompletePrompt: this.availableOptionsMessage(),
           onBeforeKeyPress: this.clearScreen.setLastCommandAt,
+          onBeforeRewrite: this.onBeforeRewrite,
           context: this.context,
           onClose: () => {
             fs.emptyDirSync(this.secrez.config.tmpPath)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
       fs-extra: 8.1.0
       homedir: 0.6.0
       inquirer: 7.3.1
-      inquirer-command-prompt: 0.0.29
+      inquirer-command-prompt: 0.0.32
       jimp: 0.13.0
       lodash: 4.17.19
       otplib: 12.0.1
@@ -218,7 +218,7 @@ importers:
       fs-extra: ^8.1.0
       homedir: ^0.6.0
       inquirer: ^7.1.0
-      inquirer-command-prompt: ^0.0.29
+      inquirer-command-prompt: ^0.0.32
       jimp: ^0.13.0
       lodash: ^4.17.15
       mocha: ^7.1.1
@@ -360,7 +360,7 @@ importers:
       nyc: ^15.1.0
       play-sound: ^1.1.3
       yaml: ^1.10.0
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.10.4:
     dependencies:
@@ -1280,10 +1280,6 @@ packages:
     optional: true
     resolution:
       integrity: sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  /bluebird/3.7.2:
-    dev: false
-    resolution:
-      integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
   /bmp-js/0.1.0:
     dev: false
     resolution:
@@ -3035,17 +3031,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-  /inquirer-command-prompt/0.0.29:
+  /inquirer-command-prompt/0.0.32:
     dependencies:
-      bluebird: 3.7.2
       chalk: 2.4.2
       fs-extra: 8.1.0
       inquirer: 6.5.2
       lodash: 4.17.19
-      preferences: 1.0.2
     dev: false
     resolution:
-      integrity: sha512-SnAGNrUN2re2sIqKl09iLDQpjK8LusEc3fezl+SUgWDflXUG6JcpJTC/53IixGUjeyeqCHK22q0jlL5Vw48YmQ==
+      integrity: sha512-7ss70a258zwP3plFMMFkeM3ojJ3NDGXC9ok1Sk8aWFAH0NcQhuFqz6PtSsPeKQPEHJ4gBGbB40Z02yIRn/PbQg==
   /inquirer/6.5.2:
     dependencies:
       ansi-escapes: 3.2.0
@@ -4639,16 +4633,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
-  /preferences/1.0.2:
-    dependencies:
-      graceful-fs: 4.2.4
-      js-yaml: 3.14.0
-      mkdirp: 0.5.5
-      os-homedir: 1.0.2
-      write-file-atomic: 1.3.4
-    dev: false
-    resolution:
-      integrity: sha512-cRjA8Galk1HDDBOKjx6DhTwfy5+FVZtH7ogg6rgTLX8Ak4wi55RaS4uRztJuVPd+md1jZo99bH/h1Q9bQQK8bg==
   /prelude-ls/1.1.2:
     dev: true
     engines:
@@ -5153,10 +5137,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  /slide/1.1.6:
-    dev: false
-    resolution:
-      integrity: sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
   /snapdragon-node/2.1.1:
     dependencies:
       define-property: 1.0.0
@@ -5875,14 +5855,6 @@ packages:
   /wrappy/1.0.2:
     resolution:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-  /write-file-atomic/1.3.4:
-    dependencies:
-      graceful-fs: 4.2.4
-      imurmurhash: 0.1.4
-      slide: 1.1.6
-    dev: false
-    resolution:
-      integrity: sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
   /write-file-atomic/3.0.3:
     dependencies:
       imurmurhash: 0.1.4
@@ -6033,6 +6005,5 @@ packages:
     dev: false
     name: readable-stream
     resolution:
-      registry: 'https://registry.npmjs.org/'
       tarball: 'https://github.com/jeffbski/readable-stream/archive/v1.0.2-object-transform2-ret-self.tar.gz'
     version: 1.0.2


### PR DESCRIPTION
This uses the new `onBeforeRewrite` option added in [inquirer-command-prompt](https://github.com/sullof/inquirer-command-prompt) v0.0.32 to remove the `#\d` prefix when autocompleting result of a `find` command.