### PR TITLE
Adding pathFrom in Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,40 @@ To mitigate this risk, you can create a new Git repo, save everything as the fir
 
 Secrez manages trees as single immutable files. During a session, temporary files are deleted to keep their number low, but at the exit, the last file remains in the repo.
 
-## Security details
 
-When you initially create a secrez database (stored, by default, in `~/.secrez`) you should indicate the number of iterations.
+## How to install it
+
+First, Secrez require at least Node 10. If you have installed a previous version it will generates unclear errors and refuse to install or work. I suggest you install Node using `nvm`, if you can. For more info look at [https://github.com/nvm-sh/nvm](https://github.com/nvm-sh/nvm).
+
+To install Secrez globally you can use Npm
+
+```
+npm install -g secrez
+```
+
+but, since this monorepo uses pnpm, it is even better if you use pnpm because the lock file will be used avoid unespected conflicts among modules.  
+To install pnpm run
+
+```
+npm i -g pnpm
+```
+and later
+```
+pnpm i -g secrez
+```
+
+## How to use it
+
+In the simplest case, you can just run
+```
+secrez
+```
+
+At first run, Secrez will ask you for the number of iterations (suggested between 500000 and 1000000, but the more the better) and a master password — ideally a phrase hard to guess, but easy to remember and type, something like, for example "heavy march with 2 eggs" or "grace was a glad president".
 
 Since Secrez derives a master key from your password using `crypto.pbkdf2`, the number of iterations is a significant addition to the general security because the number of iterations is part of the salt used for the derivation. Even if you use a not-very-hard-to-guess password, if the attacker does not know the number of iterations, he has to try all the possible ones. Considering that 2,000,000 iterations require a second or so, customizable iterations increases enormously the overall security.
 
-You can set up the number of iterations calling
+At first launch, you can also explicitly set up the number of iterations:
 ```
 secrez -i 1023896
 ```
@@ -131,26 +158,65 @@ secrez -si 876352
 ```
 where the `-s` option saves the number locally in a git-ignored `env.json` file. This way you don't have to retype it all the time to launch Secrez (typing a wrong number of iterations, of course, will produce an error).
 
-If you don't explicitly set up the number of iterations, a value for that is asked during the set up, before your password, and, if you passed the options `-s`, is saved in `env.json`.
+You can save locally the number of iterations adding the options `-s`, like:
+```
+secrez -s
+```
 
-Starting from version 0.7.0, you can change the number of iterations using, as well as the password, using `conf`.
+It is possible that the number of iterations you chose makes the initial decryption too slow. You can change it inside the Secrez CLI with the command `conf`. 
 
-Other options are:
+Other options at launch are:
 
 - `-l` to set up the initial "external" folder on you computer
-- `-c` to set up the folder where the encrypted data are located
+- `-c` to set up the container (i.e, the folder) where the encrypted data are located
 
-Both are your homedir (`~`) by default.
-Basically, running Secrez with different containers (`-c` option) you can set up multiple independent encrypted databases.
+By default, both folders are your homedir (`~`).
 
-
-## Install
-
+Running Secrez in different containers (with the `-c` option), you can set up multiple independent encrypted databases. For example:
 ```
-npm install -g secrez
+secrez -c ~/data/secrez
 ```
 
-At first run, secrez will ask you for the number of iterations (suggested between 500000 and 1000000, but the more the better) and a master password — ideally a phrase hard to guess, but easy to remember and type, something like, for example "heavy march with 2 eggs" or "grace was a glad president".
+## How to set up a Git repo for the data
+
+The best way to go is to set up a repo on your own server. If you can't do that, using a private repo on a service like GitHub is not a bad option. Let's see how you can configure it in this second case.
+
+First, you go to GitHub and create a new private repo. Don't add anything like README, Licence, etc. In the next page, GitHub will show you the command you must run to set up it locally. Here is an example, imagining that your data are in the default folder
+
+```
+cd ~/.secrez
+git init
+git commit -m "first commit"
+git branch -M main
+git remote add origin git@github.com:sullof/jarrabish.git
+git push -u origin main
+
+```
+
+In the future, I will add a `git` command inside the Secrez CLI. For now, you can use the `bash` command to update your repo when you change something, like
+```
+bash "git add . --all"
+bash "git commit -m 'some change'"
+bash "git push origin main"
+```
+
+To get faster, you can create an alias like
+```
+alias gitpush -c "lcd ~/.secrez && bash 'git add . --all' && bash 'git commit Something' && bash 'git push origin main'"
+
+```
+and, later, just execute
+```
+gitpush
+```
+every time you want to push changes to the repo.
+
+_Notice that I refer to `main` as the master branch, because recently GitHub is using that by default._ 
+
+**What about Mercurial or Subversion?**
+
+Of course, you can use a different version control system.  
+If you do so, though, be careful to correctly set up in the directory the equivalent of `.gitignore` to avoid pushing to the repo also data that must exist only locally.  
 
 ## The commands
 
@@ -328,6 +394,23 @@ You can also simulate the process to see which files will be created with the op
 
 If in the CSV file there is also the field `tags`, you can tag automatically any entries with the options `-t, --tags`. If you don't use the option, instead, they will be saved in the yaml file like any other field.
 
+**What if there is no path field?**
+
+Let's say that you want to import a CSV file exported by LastPass. There is not `path` field but you probably want to use the fields `grouping` and `name` to build the path. From version `0.8.8`, you can do it, launching, for example:
+```
+import ~/Downloads/lastpass_export.csv -e lastpass -P grouping name
+```
+or, if you like to put everything in the folder `lastpass` without generating any subfolder, you can just run
+```
+import ~/Downloads/lastpass_export.csv -e lastpass -P name -m
+```
+using only the `name` field. Still, if in the name there is any slash, a subfolder will be created. The `-m` option will remove the csv file from the OS.
+
+**Best practices**
+
+For security reason, if would be better if you do the export from you password manager and the import into Secrez as fast as possible, removing the exported file from your OS using `-m`.
+
+Still, it is convenient to edit the exported file to fix paths and names. Doing it after than the data is imported can require a lot more time. Think about it.
 
 ## Second factor authentication
 
@@ -395,6 +478,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 - Plugin architecture to allow others to add their own commands
 
 ## History
+
+__0.8.8__
+* Add the option `pathFrom` in `import` to build the `path` field using other fields
 
 __0.8.7__
 * Importing from a CSV file generates `.yaml` file instead of `.yml` 

--- a/bin/patch-versions.js
+++ b/bin/patch-versions.js
@@ -5,17 +5,11 @@ const {execSync} = require('child_process')
 let packages = {}
 execSync(`git diff master --name-only`).toString().split('\n').map(e => {
   let m = e.split('/')
-  console.log(m)
   if (m[0] === 'packages' && (m[2] === 'src' || m[2] === 'package.json')) {
     packages[m[1]] = true
   }
   return e
 })
-
-console.log(JSON.stringify(packages, null, 2))
-
-process.exit()
-
 
 let packagesFolder = fs.readdirSync(path.resolve(__dirname, '../packages'))
 

--- a/bin/patch-versions.js
+++ b/bin/patch-versions.js
@@ -5,11 +5,17 @@ const {execSync} = require('child_process')
 let packages = {}
 execSync(`git diff master --name-only`).toString().split('\n').map(e => {
   let m = e.split('/')
+  console.log(m)
   if (m[0] === 'packages' && (m[2] === 'src' || m[2] === 'package.json')) {
     packages[m[1]] = true
   }
   return e
 })
+
+console.log(JSON.stringify(packages, null, 2))
+
+process.exit()
+
 
 let packagesFolder = fs.readdirSync(path.resolve(__dirname, '../packages'))
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -115,7 +115,7 @@ To mitigate this risk, you can create a new Git repo, save everything as the fir
 
 Secrez manages trees as single immutable files. During a session, temporary files are deleted to keep their number low, but at the exit, the last file remains in the repo.
 
-## Security details
+## Security details when launching secrez
 
 When you initially create a secrez database (stored, by default, in `~/.secrez`) you should indicate the number of iterations.
 
@@ -141,7 +141,12 @@ Other options are:
 - `-c` to set up the folder where the encrypted data are located
 
 Both are your homedir (`~`) by default.
-Basically, running Secrez with different containers (`-c` option) you can set up multiple independent encrypted databases.
+Basically, running Secrez in different containers (`-c` option) you can set up multiple independent encrypted databases. For example:
+```
+secrez -c ~/data/secrez
+```
+
+
 
 
 ## Install

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Conf.js
+++ b/packages/secrez/src/commands/Conf.js
@@ -71,7 +71,7 @@ class Conf extends require('../Command') {
         ['conf -s', 'shows the general settings'],
         ['conf --fido2 -r solo',
           'registers a new key saving it as "solo"; if there are registered keys, it will checks if the new one is one of them before adding it.'],
-        ['conf', 'lists all settings, included second factors'],
+        ['conf -l', 'lists second factors'],
         ['conf --recovery-code -r memo',
           'registers an emergency recovery code called "memo" to be used if all the factors are lost'],
         ['conf --recovery-code -r seed --use-this "salad spring peace silk snake real they thunder please final clinic close"', 'registers an emergency recovery code called "seed" using the seed passed with the parameter "--use-this"'],
@@ -131,12 +131,10 @@ class Conf extends require('../Command') {
 
   async showConf(options) {
     const env = await ConfigUtils.getEnv(this.secrez.config)
-
-    // this.Logger.reset('Account settings:')
     this.Logger.reset(chalk.grey('Container: ') + this.secrez.config.container)
+    this.Logger.reset(chalk.grey('Number of iterations: ') + (env.iterations || chalk.yellow('-- not saved locally --')))
     let seconds = env.clearScreenAfter || this.cliConfig.clearScreenAfter
-    this.Logger.grey(`Clean screen after ${chalk.reset(seconds)} ${chalk.grey('seconds')}`)
-
+    this.Logger.grey(`Clean screen after: ${chalk.reset(seconds)} ${chalk.grey('seconds')}`)
   }
 
   async setClearScreenTime(options) {
@@ -407,7 +405,7 @@ class Conf extends require('../Command') {
             }
           }
         }
-      } else {
+      } else if (it) {
         let iterations = await this.useInput({
           message: 'Type the new number of iterations',
           name: 'password',
@@ -467,9 +465,9 @@ class Conf extends require('../Command') {
       return this.showHelp()
     }
     try {
-      if (!Object.keys(options).length) {
-        options.list = true
-      }
+      // if (!Object.keys(options).length) {
+      //   options.list = true
+      // }
       this.validate(options)
       if (options.fido2 && options.recoveryCode) {
         throw new Error('Conflicting params. Launch "conf -h" for examples.')

--- a/packages/secrez/src/commands/Import.js
+++ b/packages/secrez/src/commands/Import.js
@@ -96,7 +96,7 @@ class Import extends require('../Command') {
         ['import ~/data -s', 'simulates the process listing all involved files'],
         ['import backup.csv -e /imported', 'imports a backup creating files in the "/imported"'],
         ['import backup.json -e .', 'imports a backup in the current folder'],
-        ['import backup.csv -e /', 'imports a backup in the root'],
+        ['import backup.csv -e / -m', 'imports a backup in the root, deleting the CSV file from the disk'],
         ['import backup.csv -te /', 'imports a backup saving the tags field as actual tags'],
         ['import backup.csv -ute /fromPasspack',
           'uses the tags to prefix the path and keeps the tags;',
@@ -336,7 +336,7 @@ class Import extends require('../Command') {
       } else {
         if (/\.csv$/i.test(options.path)) {
           let yes = await this.useConfirm({
-            message: `You are importing a CSV file as a single file.\nMaybe, you wanted to import from a backup and forgot to specify the expand (-e) option.\nAre you sure you want to proceed?`,
+            message: 'You are importing a CSV file as a single file.\nMaybe, you wanted to import from a backup and forgot to specify the expand (-e) option.\nAre you sure you want to proceed?',
             default: false
           })
           if (!yes) {

--- a/packages/secrez/test/commands/Import.test.js
+++ b/packages/secrez/test/commands/Import.test.js
@@ -40,7 +40,7 @@ describe('#Import', function () {
     await C.import.exec({help: true})
     inspect.restore()
     let output = inspect.output.map(e => decolorize(e))
-    assert.isTrue(/-h, --help/.test(output[9]))
+    assert.isTrue(/-h, --help/.test(output[11]))
 
   })
 
@@ -271,14 +271,14 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, [
       'Imported files:',
-      '/folder/imported/webs/SampleEntryTitle.yml',
-      '/folder/imported/passwords/twitter/Multi-Line Test Entry.yml',
-      '/folder/imported/tests/Entry To Test/Special Characters.yml',
-      '/folder/imported/tests/Entry To Test/JSON data/1.yml',
-      '/folder/imported/webs/SampleEntryTitle.2.yml'
+      '/folder/imported/webs/SampleEntryTitle.yaml',
+      '/folder/imported/passwords/twitter/Multi-Line Test Entry.yaml',
+      '/folder/imported/tests/Entry To Test/Special Characters.yaml',
+      '/folder/imported/tests/Entry To Test/JSON data/1.yaml',
+      '/folder/imported/webs/SampleEntryTitle.2.yaml'
     ])
 
-    let newSecret = await C.cat.cat({path: '/folder/imported/webs/SampleEntryTitle.yml', unformatted: true})
+    let newSecret = await C.cat.cat({path: '/folder/imported/webs/SampleEntryTitle.yaml', unformatted: true})
     assert.equal(newSecret[0].type, prompt.secrez.config.types.TEXT)
     let content = fromSimpleYamlToJson(newSecret[0].content)
     assert.equal(content.password, 'ycXfARD2G1AOBzLlhtbn')
@@ -296,20 +296,20 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, [
       'Imported files:',
-      '/imported2/webs/SampleEntryTitle.yml',
-      '/imported2/passwords/twitter/Multi-Line Test Entry.yml',
-      '/imported2/tests/Entry To Test/Special Characters.yml',
-      '/imported2/tests/Entry To Test/JSON data/1.yml',
-      '/imported2/webs/SampleEntryTitle.2.yml'
+      '/imported2/webs/SampleEntryTitle.yaml',
+      '/imported2/passwords/twitter/Multi-Line Test Entry.yaml',
+      '/imported2/tests/Entry To Test/Special Characters.yaml',
+      '/imported2/tests/Entry To Test/JSON data/1.yaml',
+      '/imported2/webs/SampleEntryTitle.2.yaml'
     ])
 
-    let newSecret = await C.cat.cat({path: '/imported2/webs/SampleEntryTitle.yml', unformatted: true})
+    let newSecret = await C.cat.cat({path: '/imported2/webs/SampleEntryTitle.yaml', unformatted: true})
     assert.equal(newSecret[0].type, prompt.secrez.config.types.TEXT)
     let content = fromSimpleYamlToJson(newSecret[0].content)
     assert.equal(content.password, 'ycXfARD2G1AOBzLlhtbn')
     assert.isUndefined(content.tags)
 
-    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/webs/SampleEntryTitle.yml')
+    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/webs/SampleEntryTitle.yaml')
     assert.equal(prompt.internalFs.tree.getTags(node).join(' '), 'email eth')
 
   })
@@ -326,20 +326,20 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, [
       'Imported files:',
-      '/imported2/eth/email/webs/SampleEntryTitle.yml',
-      '/imported2/some/two/passwords/twitter/Multi-Line Test Entry.yml',
-      '/imported2/tests/Entry To Test/Special Characters.yml',
-      '/imported2/eth/web/tests/Entry To Test/JSON data/1.yml',
-      '/imported2/webs/SampleEntryTitle.yml'
+      '/imported2/eth/email/webs/SampleEntryTitle.yaml',
+      '/imported2/some/two/passwords/twitter/Multi-Line Test Entry.yaml',
+      '/imported2/tests/Entry To Test/Special Characters.yaml',
+      '/imported2/eth/web/tests/Entry To Test/JSON data/1.yaml',
+      '/imported2/webs/SampleEntryTitle.yaml'
     ])
 
-    let newSecret = await C.cat.cat({path: '/imported2/eth/email/webs/SampleEntryTitle.yml', unformatted: true})
+    let newSecret = await C.cat.cat({path: '/imported2/eth/email/webs/SampleEntryTitle.yaml', unformatted: true})
     assert.equal(newSecret[0].type, prompt.secrez.config.types.TEXT)
     let content = fromSimpleYamlToJson(newSecret[0].content)
     assert.equal(content.password, 'ycXfARD2G1AOBzLlhtbn')
     assert.isUndefined(content.tags)
 
-    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/eth/email/webs/SampleEntryTitle.yml')
+    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/eth/email/webs/SampleEntryTitle.yaml')
     assert.equal(prompt.internalFs.tree.getTags(node).length, 2)
 
   })
@@ -355,21 +355,59 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, [
       'Imported files:',
-      '/imported2/eth/email/webs/SampleEntryTitle.yml',
-      '/imported2/some/two/passwords/twitter/Multi-Line Test Entry.yml',
-      '/imported2/tests/Entry To Test/Special Characters.yml',
-      '/imported2/eth/web/tests/Entry To Test/JSON data/1.yml',
-      '/imported2/webs/SampleEntryTitle.yml'
+      '/imported2/eth/email/webs/SampleEntryTitle.yaml',
+      '/imported2/some/two/passwords/twitter/Multi-Line Test Entry.yaml',
+      '/imported2/tests/Entry To Test/Special Characters.yaml',
+      '/imported2/eth/web/tests/Entry To Test/JSON data/1.yaml',
+      '/imported2/webs/SampleEntryTitle.yaml'
     ])
 
-    let newSecret = await C.cat.cat({path: '/imported2/eth/email/webs/SampleEntryTitle.yml', unformatted: true})
+    let newSecret = await C.cat.cat({path: '/imported2/eth/email/webs/SampleEntryTitle.yaml', unformatted: true})
     assert.equal(newSecret[0].type, prompt.secrez.config.types.TEXT)
     let content = fromSimpleYamlToJson(newSecret[0].content)
     assert.equal(content.password, 'ycXfARD2G1AOBzLlhtbn')
     assert.isUndefined(content.tags)
 
-    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/eth/email/webs/SampleEntryTitle.yml')
+    let node = prompt.internalFs.tree.root.getChildFromPath('/imported2/eth/email/webs/SampleEntryTitle.yaml')
     assert.equal(prompt.internalFs.tree.getTags(node).length, 0)
+
+  })
+
+  it('should import from a LastPass-like csv setting the path from "grouping" and "name"', async function () {
+
+    inspect = stdout.inspect()
+    await C.import.exec({
+      path: '../lastpass_export.csv',
+      expand: './lastpass',
+      pathFrom: ['grouping', 'name'],
+      useTagsForPaths: true
+    })
+
+    inspect.restore()
+    assertConsole(inspect, [
+      'Imported files:',
+      '/lastpass/News/Reference/HackerNews/YC.yaml',
+      '/lastpass/Productivity Tools/asana.com.yaml',
+      '/lastpass/lombardstreet.io WP.yaml',
+      '/lastpass/amazon.it personal.yaml'
+    ])
+
+    inspect = stdout.inspect()
+    await C.import.exec({
+      path: '../lastpass_export.csv',
+      expand: './lastpass2',
+      pathFrom: ['not_existing', 'name'],
+      useTagsForPaths: true
+    })
+
+    inspect.restore()
+    assertConsole(inspect, [
+      'Imported files:',
+      '/lastpass2/HackerNews/YC.yaml',
+      '/lastpass2/asana.com.yaml',
+      '/lastpass2/lombardstreet.io WP.yaml',
+      '/lastpass2/amazon.it personal.yaml'
+    ])
 
   })
 
@@ -383,10 +421,10 @@ describe('#Import', function () {
     inspect.restore()
     assertConsole(inspect, [
       'Imported files:',
-      '/imported3/webs/SampleEntryTitle.yml',
-      '/imported3/passwords/twitter/Multi-Line Test Entry.yml',
-      '/imported3/tests/Entry To Test/Special Characters.yml',
-      '/imported3/tests/Entry To Test/JSON data/1.yml'
+      '/imported3/webs/SampleEntryTitle.yaml',
+      '/imported3/passwords/twitter/Multi-Line Test Entry.yaml',
+      '/imported3/tests/Entry To Test/Special Characters.yaml',
+      '/imported3/tests/Entry To Test/JSON data/1.yaml'
     ])
 
   })
@@ -425,6 +463,20 @@ describe('#Import', function () {
     })
     inspect.restore()
     assertConsole(inspect, ['The header of the CSV looks wrong'])
+
+  })
+
+  it('should throw importing a CSV indicating wrong fields to generate the path', async function () {
+
+    inspect = stdout.inspect()
+    await C.import.exec({
+      path: '../lastpass_export.csv',
+      expand: './lastpass',
+      pathFrom: ['folder'],
+      useTagsForPaths: true
+    })
+    inspect.restore()
+    assertConsole(inspect, ['Path cannot be built from the specified fields'])
 
   })
 

--- a/packages/secrez/test/fixtures/lastpass_export.csv
+++ b/packages/secrez/test/fixtures/lastpass_export.csv
@@ -1,0 +1,5 @@
+url,username,password,extra,name,grouping,fav
+https://news.ycombinator.com/login,johnExamplle,i838ewhfs,,HackerNews/YC,News/Reference,0
+https://app.asana.com/app/asana/-/login,some@example.io,sakk3333,,asana.com,Productivity Tools,0
+http://lombardstreet.io/wp-login.php,Max,sdadadsa,,lombardstreet.io WP,,0
+https://www.amazon.it/ap/signin,john.example@gmail.com,leosj3837wjd,,amazon.it personal,,0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ importers:
       '@secrez/utils': 'link:../utils'
       base-x: 3.0.8
       bip39: 3.0.2
-      blake3: 2.1.4
       fs-extra: 8.1.0
       homedir: 0.6.0
       lodash: 4.17.19
@@ -31,7 +30,6 @@ importers:
       '@secrez/utils': 'workspace:~0.1.5'
       base-x: ^3.0.8
       bip39: ^3.0.2
-      blake3: ^2.1.4
       chai: ^4.2.0
       cross-env: ^7.0.2
       eslint: ^6.8.0
@@ -72,7 +70,7 @@ importers:
       eslint: 6.8.0
       mocha: 7.2.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/fs': 'workspace:~0.8.4'
       '@secrez/hub': 'workspace:~0.1.5'
       '@secrez/test-helpers': 'workspace:~0.1.3'
@@ -110,7 +108,7 @@ importers:
       mocha: 7.2.0
       nyc: 15.1.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/test-helpers': 'workspace:~0.1.3'
       '@secrez/utils': 'workspace:~0.1.5'
       chai: ^4.2.0
@@ -146,7 +144,7 @@ importers:
       supertest: 4.0.2
       ws: 7.3.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/test-helpers': 'workspace:~0.1.3'
       '@secrez/tls': 'workspace:~0.1.3'
       '@secrez/utils': 'workspace:~0.1.5'
@@ -199,7 +197,7 @@ importers:
       nyc: 15.1.0
       test-console: 1.1.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/courier': 'workspace:~0.1.4'
       '@secrez/fs': 'workspace:~0.8.4'
       '@secrez/hub': 'workspace:~0.1.5'
@@ -247,7 +245,7 @@ importers:
       mocha: 7.2.0
       nyc: 15.1.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/fs': 'workspace:~0.8.4'
       '@secrez/hub': 'workspace:~0.1.5'
       '@secrez/utils': 'workspace:~0.1.5'
@@ -308,7 +306,7 @@ importers:
       mocha: 7.2.0
       nyc: 15.1.0
     specifiers:
-      '@secrez/core': 'workspace:~0.8.6'
+      '@secrez/core': 'workspace:~0.8.7'
       '@secrez/hub': 'workspace:~0.1.5'
       '@secrez/test-helpers': 'workspace:~0.1.3'
       '@secrez/tls': 'workspace:~0.1.3'
@@ -1266,11 +1264,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==
-  /blake3/2.1.4:
-    dev: false
-    requiresBuild: true
-    resolution:
-      integrity: sha512-70hmx0lPd6zmtNwxPT4/1P0pqaEUlTJ0noUBvCXPLfMpN0o8PPaK3q7ZlpRIyhrqcXxeMAJSowNm/L9oi/x1XA==
   /block-stream/0.0.9:
     dependencies:
       inherits: 2.0.4


### PR DESCRIPTION
If in a CSV file there is no field `path` you can use the option `-P` (or `--pathFrom`) to specify which fields should be used to build the path. You can indicate a single field or more than one. Like
```
import ~/Downloads/lastpass_export.csv -e lastpass -P grouping name
```
