### PR TITLE
Force def editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,12 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.8.10__
+* If the default editor is not defined (env variable EDITOR) try to use nano or vim
+
+__0.8.9__
+* Pause clearScreen during editing
+
 __0.8.8__
 * Add the option `pathFrom` in `import` to build the `path` field using other fields
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -479,6 +479,12 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.8.10__
+* If the default editor is not defined (env variable EDITOR) try to use nano or vim
+
+__0.8.9__
+* Pause clearScreen during editing
+
 __0.8.8__
 * Add the option `pathFrom` in `import` to build the `path` field using other fields
 

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -5,7 +5,7 @@ require('tiny-cli-editor')
 const _ = require('lodash')
 const path = require('path')
 const fs = require('fs-extra')
-const {isYaml, yamlParse, yamlStringify} = require('@secrez/utils')
+const {isYaml, yamlParse, yamlStringify, execAsync} = require('@secrez/utils')
 
 class Edit extends require('../Command') {
 
@@ -166,6 +166,19 @@ class Edit extends require('../Command') {
         process.env.EDITOR = this.getTinyCliEditorBinPath()
       } else if (options.editor) {
         process.env.EDITOR = options.editor
+      }
+      if (!process.env.EDITOR) {
+        let result = await execAsync('which', __dirname, ['nano'])
+        if (!result.message || result.code === 1) {
+          result = await execAsync('which', __dirname, ['vim'])
+          if (!result.message || result.code === 1) {
+            this.Logger.red('No text editor found')
+          } else {
+            process.env.EDITOR = 'vim'
+          }
+        } else {
+          process.env.EDITOR = 'nano'
+        }
       }
       await this.edit(options)
     } catch (e) {

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -172,7 +172,7 @@ class Edit extends require('../Command') {
         if (!result.message || result.code === 1) {
           result = await execAsync('which', __dirname, ['vim'])
           if (!result.message || result.code === 1) {
-            throw new Error('No text editor found. Set up the EDITOR env variable or use the -e option to use your text editor. Type "edit -h" for more options.')
+            throw new Error('No text editor found. Set up the EDITOR env variable or use the -e option. Type "edit -h" for more options.')
           } else {
             process.env.EDITOR = 'vim'
           }

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -172,7 +172,7 @@ class Edit extends require('../Command') {
         if (!result.message || result.code === 1) {
           result = await execAsync('which', __dirname, ['vim'])
           if (!result.message || result.code === 1) {
-            this.Logger.red('No text editor found')
+            process.env.EDITOR = this.getTinyCliEditorBinPath()
           } else {
             process.env.EDITOR = 'vim'
           }

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -172,7 +172,7 @@ class Edit extends require('../Command') {
         if (!result.message || result.code === 1) {
           result = await execAsync('which', __dirname, ['vim'])
           if (!result.message || result.code === 1) {
-            process.env.EDITOR = this.getTinyCliEditorBinPath()
+            throw new Error('No text editor found. Set up the EDITOR env variable. Alternatively, you can use the internal tiny editor adding the option -i')
           } else {
             process.env.EDITOR = 'vim'
           }

--- a/packages/secrez/src/commands/Edit.js
+++ b/packages/secrez/src/commands/Edit.js
@@ -172,7 +172,7 @@ class Edit extends require('../Command') {
         if (!result.message || result.code === 1) {
           result = await execAsync('which', __dirname, ['vim'])
           if (!result.message || result.code === 1) {
-            throw new Error('No text editor found. Set up the EDITOR env variable. Alternatively, you can use the internal tiny editor adding the option -i')
+            throw new Error('No text editor found. Set up the EDITOR env variable or use the -e option to use your text editor. Type "edit -h" for more options.')
           } else {
             process.env.EDITOR = 'vim'
           }


### PR DESCRIPTION
If the environment variable EDITOR is not set, it search for installed editors — before for nano and after for vim — and uses what it finds. If none of them is installed, it produces and error suggesting to use the internal tiny editor if nothing else is available.