### PR TITLE
Fixing mistaken dataset in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.9.4__
+* fix bug during import, if a `path` contains `:`; now, they are replaced with `_`
+
 __0.9.3__
 * fix bug with `ds -l` not working
 
@@ -749,7 +752,7 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  155 passing (25s)
+  155 passing (23s)
   1 pending
 
 -----------------------|---------|----------|---------|---------|-----------------------------------
@@ -818,7 +821,7 @@ All files              |   66.05 |    53.41 |    68.6 |   65.93 |
   Logger.js            |   63.64 |    56.25 |   36.84 |   62.79 | ...38-50,58,66-70,75,85,89,94,107 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 
-> secrez@0.9.3 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez
+> secrez@0.9.4 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez
 > nyc check-coverage --statements 65 --branches 50 --functions 65 --lines 65
 
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -472,6 +472,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__0.9.4__
+* fix bug during import, if a `path` contains `:`; now, they are replaced with `_`
+
 __0.9.3__
 * fix bug with `ds -l` not working
 
@@ -749,7 +752,7 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  155 passing (25s)
+  155 passing (23s)
   1 pending
 
 -----------------------|---------|----------|---------|---------|-----------------------------------
@@ -818,7 +821,7 @@ All files              |   66.05 |    53.41 |    68.6 |   65.93 |
   Logger.js            |   63.64 |    56.25 |   36.84 |   62.79 | ...38-50,58,66-70,75,85,89,94,107 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 
-> secrez@0.9.3 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez
+> secrez@0.9.4 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez
 > nyc check-coverage --statements 65 --branches 50 --functions 65 --lines 65
 
 

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",

--- a/packages/secrez/src/commands/Import.js
+++ b/packages/secrez/src/commands/Import.js
@@ -222,7 +222,7 @@ class Import extends require('../Command') {
           if (!p) {
             throw new Error('Path cannot be built from the specified fields')
           }
-          item.path = p.replace(/\/+/g, '/')
+          item.path = p.replace(/\/+/g, '/').replace(/:+/g, '_')
         }
       } else {
         return this.Logger.red('The data misses a path field')

--- a/packages/secrez/test/commands/Import.test.js
+++ b/packages/secrez/test/commands/Import.test.js
@@ -388,7 +388,7 @@ describe('#Import', function () {
       'Imported files:',
       '/lastpass/News/Reference/HackerNews/YC.yaml',
       '/lastpass/Productivity Tools/asana.com.yaml',
-      '/lastpass/lombardstreet.io WP.yaml',
+      '/lastpass/http_/lombardstreet.io WP.yaml',
       '/lastpass/amazon.it personal.yaml'
     ])
 
@@ -405,8 +405,25 @@ describe('#Import', function () {
       'Imported files:',
       '/lastpass2/HackerNews/YC.yaml',
       '/lastpass2/asana.com.yaml',
-      '/lastpass2/lombardstreet.io WP.yaml',
+      '/lastpass2/http_/lombardstreet.io WP.yaml',
       '/lastpass2/amazon.it personal.yaml'
+    ])
+
+    inspect = stdout.inspect()
+    await C.import.exec({
+      path: '../lastpass_export.csv',
+      expand: './lastpass3',
+      pathFrom: ['name'],
+      useTagsForPaths: true
+    })
+
+    inspect.restore()
+    assertConsole(inspect, [
+      'Imported files:',
+      '/lastpass3/HackerNews/YC.yaml',
+      '/lastpass3/asana.com.yaml',
+      '/lastpass3/http_/lombardstreet.io WP.yaml',
+      '/lastpass3/amazon.it personal.yaml'
     ])
 
   })

--- a/packages/secrez/test/fixtures/lastpass_export.csv
+++ b/packages/secrez/test/fixtures/lastpass_export.csv
@@ -1,5 +1,5 @@
 url,username,password,extra,name,grouping,fav
 https://news.ycombinator.com/login,johnExamplle,i838ewhfs,,HackerNews/YC,News/Reference,0
 https://app.asana.com/app/asana/-/login,some@example.io,sakk3333,,asana.com,Productivity Tools,0
-http://lombardstreet.io/wp-login.php,Max,sdadadsa,,lombardstreet.io WP,,0
+http://lombardstreet.io/wp-login.php,vito,sdadadsa,,http://lombardstreet.io WP,,0
 https://www.amazon.it/ap/signin,john.example@gmail.com,leosj3837wjd,,amazon.it personal,,0


### PR DESCRIPTION
Fix a bug during import. If the `path` contains a `:` Secrez thinks it is a dataset and if the dataset does not exists produces an error. In this version, the `:` is replaced with an underscore.