### PR TITLE
Fix issue with empty old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,17 +188,11 @@ The best way to go is to set up a repo on your own server. If you can't do that,
 First, you go to GitHub and create a new private repo. Don't add anything like README, Licence, etc. In the next page, GitHub will show you the command you must run to set up it locally. Here is an example, imagining that your data are in the default folder
 
 ```
-cd ~/.secrez
-git init
-git commit -m "first commit"
-git branch -M main
-git remote add origin git@github.com:sullof/jarrabish.git
-git push -u origin main
-
+git --init --main-branch main
+git --remote-url git@github.com:sullof/jarrabish.git
 ```
 
-Since version 0.10.2 you can use the internal `git` command.
-It is very easy. To push any change run
+To push any change run
 ```
 git -p
 ```
@@ -208,16 +202,31 @@ git -P
 ```
 Notice that the lowercase `p` is an alias for `push` and the uppercase `P` for `pull`.
 
-**What about Mercurial or Subversion?**
+### What if I have a private remote repo?
 
-Of course, you can use a different version control system.  
+You should use Git anyway, to have a safe backup of your data. In this case, just run
+```
+git --init
+```
+to set the repo up. After, use `git -p` to commit your changes. It will allow you to reverse the data in case some critical error occurs. When you have a private repo, you can just add the remote url (see example above).
+
+If you need more, you can run commands using Shell, like
+```
+shell "cd ~/.secrez && git log"
+```
+However, if you like to do some reset, you should quit and run the commands directly in the shell.
+
+**Be careful when you do anything inside your container, you can irreversibly damage your data.**
+
+### What about Mercurial or Subversion?
+
+You can use a different version control system.  
 If you do so, though, be careful to correctly set up in the directory the equivalent of `.gitignore` to avoid pushing to the repo also data that must exist only locally.
 
 ## The commands
 
 ```
   alias     Create aliases of other commands.
-  bash      Execute a bash command in the current disk folder.
   cat       Shows the content of a file.
   cd        Changes the working directory.
   chat      Enters the Secrez chat
@@ -252,6 +261,7 @@ If you do so, though, be careful to correctly set up in the directory the equiva
   pwd       Shows the path of the working directory.
   quit      Quits Secrez.
   rm        Removes one or more files and folders.
+  shell     Execute a bash command in the current disk folder.
   ssh       Opens a new tab and run ssh to connect to a remote server via SSH
   tag       Tags a file and shows existent tags.
   totp      Generate a TOTP code if a totp field exists in the card.
@@ -395,7 +405,7 @@ You can also simulate the process to see which files will be created with the op
 
 If in the CSV file there is also the field `tags`, you can tag automatically any entries with the options `-t, --tags`. If you don't use the option, instead, they will be saved in the yaml file like any other field.
 
-**What if there is no path field?**
+### What if there is no path field?
 
 Let's say that you want to import a CSV file exported by LastPass. There is not `path` field but you probably want to use the fields `grouping` and `name` to build the path. From version `0.8.8`, you can do it, launching, for example:
 ```
@@ -409,7 +419,7 @@ using only the `name` field. Still, if in the name there is any slash, a subfold
 
 In these two examples, be sure that any of your entries in LastPass has a name. If not, the import will fail because it does't know how to call the file.
 
-**Best practices**
+### Best practices
 
 For security reason, if would be better if you do the export from you password manager and the import into Secrez as fast as possible, removing the exported file from your OS using `-m`.
 
@@ -441,13 +451,14 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
-__0.11.0__
-* uses @secrez/core@0.9.0, which changes the encoding from base58 to base64, making the app super faster
-* remove second factor authentication due to potentially critical issues with Python and the required libraries on MacOS (2FA will be restored as soon as a pure Javascript library is available)
+__1.0.0__
+* use @secrez/core@1.0.0, which changes the encoding from base58 to base64, making the encoding much faster
+* remove second factor authentication due to potentially critical issues with Python and the required libraries on macOS (2FA will be restored as soon as either a pure Javascript library is available or using external Python libraries is reliable again)
 * `Bash` has been renamed `Shell`
+* Git has new options `--init`, `--remote-url` and `--main-branch` to initiate a repo from inside Secrez
 
 __0.10.8__
-* exposes a prompt mock to allow other software to run commands programmatically
+* expose a prompt mock to allow other software to run commands programmatically
 * fix bug in totp when the command is called but no totp is set
 
 __0.10.7__
@@ -762,18 +773,18 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  157 passing (24s)
+  157 passing (25s)
   1 pending
 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                 
 -----------------------|---------|----------|---------|---------|-----------------------------------
-All files              |   70.16 |    56.34 |   71.61 |    70.1 |                                   
+All files              |   69.59 |     55.5 |   71.87 |   69.52 |                                   
  src                   |   59.63 |    54.79 |      55 |   61.32 |                                   
   Command.js           |   79.66 |    78.72 |   76.92 |   83.93 | 35,54-59,68,71,95                 
   PreCommand.js        |   21.95 |    11.54 |   14.29 |   21.95 | 9-95,108                          
   cliConfig.js         |     100 |      100 |     100 |     100 |                                   
- src/commands          |   80.14 |    64.71 |   89.14 |   79.94 |                                   
+ src/commands          |   79.13 |    63.34 |   89.14 |   78.92 |                                   
   Alias.js             |   90.54 |    77.36 |     100 |   90.41 | 85,96,118,145,149,154,164         
   Bash.js              |      75 |        0 |   66.67 |      75 | 20-21                             
   Cat.js               |    98.9 |    88.89 |     100 |    98.9 | 144                               
@@ -787,7 +798,7 @@ All files              |   70.16 |    56.34 |   71.61 |    70.1 |
   Edit.js              |   13.58 |        0 |      40 |   13.58 | 78-193                            
   Export.js            |     100 |    68.75 |     100 |     100 | 56,76,88-93,100                   
   Find.js              |   93.59 |    86.67 |     100 |   93.42 | 90,153,192-196,202                
-  Git.js               |   22.45 |        0 |      50 |   22.45 | 51-113                            
+  Git.js               |   15.07 |        0 |      50 |   15.07 | 74-178                            
   Help.js              |     100 |       80 |     100 |     100 | 30                                
   Import.js            |   93.68 |    83.96 |     100 |   93.57 | ...59,261,274,280,322,337-343,359 
   Lcat.js              |     100 |    85.71 |     100 |     100 | 55                                
@@ -828,12 +839,12 @@ All files              |   70.16 |    56.34 |   71.61 |    70.1 |
   MainPromptMock.js    |     100 |      100 |   66.67 |     100 |                                   
   MultiEditorPrompt.js |      25 |        0 |       0 |      25 | 8-35                              
   SigintManager.js     |      25 |        0 |      20 |      25 | 11-37                             
- src/utils             |   69.92 |     62.1 |   56.25 |   69.55 |                                   
+ src/utils             |   70.33 |     62.1 |   58.33 |   69.96 |                                   
   AliasManager.js      |     100 |    91.67 |     100 |     100 | 48                                
   ContactManager.js    |   71.43 |       60 |   85.71 |   71.43 | 13,36-38                          
   Fido2Client.js       |   15.38 |        0 |   11.11 |   15.38 | 15-101                            
   HelpProto.js         |    91.6 |    83.08 |     100 |   91.45 | 44,137-138,155-160,179            
-  Logger.js            |   63.64 |    56.25 |   36.84 |   62.79 | ...38-50,58,66-70,75,85,89,94,107 
+  Logger.js            |   65.91 |    56.25 |   42.11 |   65.12 | ...42-50,58,66-70,75,85,89,94,107 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 
 > secrez@1.0.0-beta.1 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/migrate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/migrate/src/migrations/MigrateFromV1ToV2.js
+++ b/packages/migrate/src/migrations/MigrateFromV1ToV2.js
@@ -224,9 +224,9 @@ and contact secrez@sullo.co for help.
   }
 
   async migrateTree(node, newNode) {
-    await this.current.tree0.getEntryDetails(node)
     if (node.versions) {
       for (let ts in node.versions) {
+        await this.current.tree0.getEntryDetails(node, ts)
         let version = node.versions[ts]
         let {name, content} = version
         let entry = new Entry({
@@ -239,10 +239,6 @@ and contact secrez@sullo.co for help.
         })
         let encryptedEntry = this.secrez.encryptEntry(entry, 'useTs')
         newNode.addVersion(encryptedEntry)
-
-        // console.log(JSON.stringify(version, null, 2))
-        // console.log(JSON.stringify(newNode.versions[ts], null, 2))
-
         await fs.writeFile(path.join(this.container, 'data' + (this.current.index ? '.' + this.current.index : ''), encryptedEntry.encryptedName), entry.content ? encryptedEntry.encryptedContent : '')
       }
     }

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -188,17 +188,11 @@ The best way to go is to set up a repo on your own server. If you can't do that,
 First, you go to GitHub and create a new private repo. Don't add anything like README, Licence, etc. In the next page, GitHub will show you the command you must run to set up it locally. Here is an example, imagining that your data are in the default folder
 
 ```
-cd ~/.secrez
-git init
-git commit -m "first commit"
-git branch -M main
-git remote add origin git@github.com:sullof/jarrabish.git
-git push -u origin main
-
+git --init --main-branch main
+git --remote-url git@github.com:sullof/jarrabish.git
 ```
 
-Since version 0.10.2 you can use the internal `git` command.
-It is very easy. To push any change run
+To push any change run
 ```
 git -p
 ```
@@ -208,16 +202,31 @@ git -P
 ```
 Notice that the lowercase `p` is an alias for `push` and the uppercase `P` for `pull`.
 
-**What about Mercurial or Subversion?**
+### What if I have a private remote repo?
 
-Of course, you can use a different version control system.  
+You should use Git anyway, to have a safe backup of your data. In this case, just run
+```
+git --init
+```
+to set the repo up. After, use `git -p` to commit your changes. It will allow you to reverse the data in case some critical error occurs. When you have a private repo, you can just add the remote url (see example above).
+
+If you need more, you can run commands using Shell, like
+```
+shell "cd ~/.secrez && git log"
+```
+However, if you like to do some reset, you should quit and run the commands directly in the shell.
+
+**Be careful when you do anything inside your container, you can irreversibly damage your data.**
+
+### What about Mercurial or Subversion?
+
+You can use a different version control system.  
 If you do so, though, be careful to correctly set up in the directory the equivalent of `.gitignore` to avoid pushing to the repo also data that must exist only locally.
 
 ## The commands
 
 ```
   alias     Create aliases of other commands.
-  bash      Execute a bash command in the current disk folder.
   cat       Shows the content of a file.
   cd        Changes the working directory.
   chat      Enters the Secrez chat
@@ -252,6 +261,7 @@ If you do so, though, be careful to correctly set up in the directory the equiva
   pwd       Shows the path of the working directory.
   quit      Quits Secrez.
   rm        Removes one or more files and folders.
+  shell     Execute a bash command in the current disk folder.
   ssh       Opens a new tab and run ssh to connect to a remote server via SSH
   tag       Tags a file and shows existent tags.
   totp      Generate a TOTP code if a totp field exists in the card.
@@ -395,7 +405,7 @@ You can also simulate the process to see which files will be created with the op
 
 If in the CSV file there is also the field `tags`, you can tag automatically any entries with the options `-t, --tags`. If you don't use the option, instead, they will be saved in the yaml file like any other field.
 
-**What if there is no path field?**
+### What if there is no path field?
 
 Let's say that you want to import a CSV file exported by LastPass. There is not `path` field but you probably want to use the fields `grouping` and `name` to build the path. From version `0.8.8`, you can do it, launching, for example:
 ```
@@ -409,7 +419,7 @@ using only the `name` field. Still, if in the name there is any slash, a subfold
 
 In these two examples, be sure that any of your entries in LastPass has a name. If not, the import will fail because it does't know how to call the file.
 
-**Best practices**
+### Best practices
 
 For security reason, if would be better if you do the export from you password manager and the import into Secrez as fast as possible, removing the exported file from your OS using `-m`.
 
@@ -441,13 +451,14 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
-__0.11.0__
-* uses @secrez/core@0.9.0, which changes the encoding from base58 to base64, making the app super faster
-* remove second factor authentication due to potentially critical issues with Python and the required libraries on MacOS (2FA will be restored as soon as a pure Javascript library is available)
+__1.0.0__
+* use @secrez/core@1.0.0, which changes the encoding from base58 to base64, making the encoding much faster
+* remove second factor authentication due to potentially critical issues with Python and the required libraries on macOS (2FA will be restored as soon as either a pure Javascript library is available or using external Python libraries is reliable again)
 * `Bash` has been renamed `Shell`
+* Git has new options `--init`, `--remote-url` and `--main-branch` to initiate a repo from inside Secrez
 
 __0.10.8__
-* exposes a prompt mock to allow other software to run commands programmatically
+* expose a prompt mock to allow other software to run commands programmatically
 * fix bug in totp when the command is called but no totp is set
 
 __0.10.7__
@@ -762,18 +773,18 @@ Thanks a lot for any contribution 😉
 ## Test coverage
 
 ```
-  157 passing (24s)
+  157 passing (25s)
   1 pending
 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                 
 -----------------------|---------|----------|---------|---------|-----------------------------------
-All files              |   70.16 |    56.34 |   71.61 |    70.1 |                                   
+All files              |   69.59 |     55.5 |   71.87 |   69.52 |                                   
  src                   |   59.63 |    54.79 |      55 |   61.32 |                                   
   Command.js           |   79.66 |    78.72 |   76.92 |   83.93 | 35,54-59,68,71,95                 
   PreCommand.js        |   21.95 |    11.54 |   14.29 |   21.95 | 9-95,108                          
   cliConfig.js         |     100 |      100 |     100 |     100 |                                   
- src/commands          |   80.14 |    64.71 |   89.14 |   79.94 |                                   
+ src/commands          |   79.13 |    63.34 |   89.14 |   78.92 |                                   
   Alias.js             |   90.54 |    77.36 |     100 |   90.41 | 85,96,118,145,149,154,164         
   Bash.js              |      75 |        0 |   66.67 |      75 | 20-21                             
   Cat.js               |    98.9 |    88.89 |     100 |    98.9 | 144                               
@@ -787,7 +798,7 @@ All files              |   70.16 |    56.34 |   71.61 |    70.1 |
   Edit.js              |   13.58 |        0 |      40 |   13.58 | 78-193                            
   Export.js            |     100 |    68.75 |     100 |     100 | 56,76,88-93,100                   
   Find.js              |   93.59 |    86.67 |     100 |   93.42 | 90,153,192-196,202                
-  Git.js               |   22.45 |        0 |      50 |   22.45 | 51-113                            
+  Git.js               |   15.07 |        0 |      50 |   15.07 | 74-178                            
   Help.js              |     100 |       80 |     100 |     100 | 30                                
   Import.js            |   93.68 |    83.96 |     100 |   93.57 | ...59,261,274,280,322,337-343,359 
   Lcat.js              |     100 |    85.71 |     100 |     100 | 55                                
@@ -828,12 +839,12 @@ All files              |   70.16 |    56.34 |   71.61 |    70.1 |
   MainPromptMock.js    |     100 |      100 |   66.67 |     100 |                                   
   MultiEditorPrompt.js |      25 |        0 |       0 |      25 | 8-35                              
   SigintManager.js     |      25 |        0 |      20 |      25 | 11-37                             
- src/utils             |   69.92 |     62.1 |   56.25 |   69.55 |                                   
+ src/utils             |   70.33 |     62.1 |   58.33 |   69.96 |                                   
   AliasManager.js      |     100 |    91.67 |     100 |     100 | 48                                
   ContactManager.js    |   71.43 |       60 |   85.71 |   71.43 | 13,36-38                          
   Fido2Client.js       |   15.38 |        0 |   11.11 |   15.38 | 15-101                            
   HelpProto.js         |    91.6 |    83.08 |     100 |   91.45 | 44,137-138,155-160,179            
-  Logger.js            |   63.64 |    56.25 |   36.84 |   62.79 | ...38-50,58,66-70,75,85,89,94,107 
+  Logger.js            |   65.91 |    56.25 |   42.11 |   65.12 | ...42-50,58,66-70,75,85,89,94,107 
 -----------------------|---------|----------|---------|---------|-----------------------------------
 
 > secrez@1.0.0-beta.1 posttest /Users/sullof/Projects/Personal/secrez/packages/secrez

--- a/packages/secrez/src/commands/Cat.js
+++ b/packages/secrez/src/commands/Cat.js
@@ -79,7 +79,7 @@ class Cat extends require('../Command') {
     let date = ts[0].split('Z')[0].split('T')
     let ret = `${tsHash}  ${date[0]}  ${date[1].substring(0, 12)}${ts[1]}`
     if (name) {
-      ret += chalk.yellow(' (' + name + ')')
+      ret += chalk.grey(' (' + name + ')')
     }
 
     return ret
@@ -186,7 +186,7 @@ class Cat extends require('../Command') {
         for (let d of data) {
           let {content, ts, type, name} = d
           if (extra) {
-            this.Logger.grey(`${this.formatTs(ts, fn === name ? undefined : name)}`)
+            this.Logger.green(`${this.formatTs(ts, fn === name ? undefined : name)}`)
           }
           if (type === config.types.TEXT) {
             if (_.trim(content)) {

--- a/packages/secrez/src/commands/Git.js
+++ b/packages/secrez/src/commands/Git.js
@@ -32,17 +32,40 @@ class Git extends require('../Command') {
         name: 'info',
         alias: 'i',
         type: Boolean
+      },
+      {
+        name: 'message',
+        type: String
+      },
+      {
+        name: 'init',
+        type: Boolean
+      },
+      {
+        name: 'remote-url',
+        type: String
+      },
+      {
+        name: 'main-branch',
+        type: String
       }
     ]
   }
 
   help() {
     return {
-      description: ['Pushes to a repo and pulls from a repo.', 'The repo must be set up outside secrez!'],
+      description: ['Minimalistic git repo managements.',
+        'For missing commands use "shell" instead, like:',
+        'shell "cd ~/.secrez && git history"'],
       examples: [
-        ['git -p', 'adds, commits and pushes to the remote repo; a message is not allowed because it is better not to give any help to a possible hacker about whatever you are committing'],
-        ['git -P', '(notice the uppercase P) pulls from origin and merges'],
-        ['git -i', 'get info about the repo, like the remote url']
+        ['git -i', 'get info about the repo, like the remote url'],
+        ['git -p', 'adds all changes and commits. If there is a remote origin, it also pushes to the remote repo'],
+        ['git -p --message "before migrating the db"', 'adds a message to the push; in general, it is better to not specify messages, but in some special case, it can be useful to add a message'],
+        ['git --init', 'initiates a git repo using "master" as main branch'],
+        ['git --init --main-branch main', 'initiates a git repo using "main" as main branch'],
+        ['git --main-branch main', 'sets the main branch'],
+        ['git --remote-url git@github.com:sullof/priv-repo.git', 'sets the origin of the local repo'],
+        ['git -P', '(notice the uppercase P) pulls from origin and merges']
       ]
     }
   }
@@ -53,22 +76,44 @@ class Git extends require('../Command') {
       throw new Error('Git not installed')
     }
     let containerPath = this.secrez.config.container
-    if (!(await fs.pathExists(path.join(containerPath, '.git')))) {
-      throw new Error('Repo not found')
+    let repoExists = await fs.pathExists(path.join(containerPath, '.git'))
+
+    if (options.init) {
+      if (repoExists) {
+        throw new Error('Repo already initiated.')
+      }
+      let res = (await execAsync('git', containerPath, ['init'])).message
+      await execAsync('git', containerPath, ['add', '-A'])
+      res += '\n' + (await execAsync('git', containerPath, ['commit', '-m', 'first-commit'])).message
+      await execAsync('git', containerPath, ['branch', '-M', options.mainBranch || 'master'])
+      return res
     }
+
+    if (options.mainBranch) {
+      await execAsync('git', containerPath, ['branch', '-M', options.mainBranch])
+      return `New main branch: ${options.mainBranch}`
+    }
+
+    if (!repoExists) {
+      throw new Error('Repo not found. Run "git --init" to initiate the repo')
+    }
+
     result = await execAsync('git', containerPath, ['remote', '-v'])
-    if (!result.message || result.code === 1) {
-      throw new Error('No remote origin found')
-    }
     let remoteUrl
-    for (let line of result.message.split('\n')) {
-      if (/^origin/.test(line) && /\(push\)/.test(line)) {
-        remoteUrl = line.replace(/origin\s+(.+)\s+\(push.+/, '$1')
-        break
+    if (result.message && result.code !== 1) {
+      for (let line of result.message.split('\n')) {
+        if (/^origin/.test(line) && /\(push\)/.test(line)) {
+          remoteUrl = line.replace(/origin\s+(.+)\s+\(push.+/, '$1')
+          break
+        }
       }
     }
-    if (!remoteUrl) {
-      throw new Error('No remote origin found')
+    if (options.remoteUrl) {
+      if (remoteUrl) {
+        await execAsync('git', containerPath, ['remote','remove','origin'])
+      }
+      await execAsync('git', containerPath, ['remote', 'add', 'origin', options.remoteUrl])
+      return `Remote url: ${options.remoteUrl}`
     }
 
     result = await execAsync('git', containerPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
@@ -77,12 +122,30 @@ class Git extends require('../Command') {
     }
     let branch = _.trim(result.message)
 
+    result = await execAsync('git', containerPath, ['diff', '--name-only'])
+    let count = 0
+    if (_.trim(result.message)) {
+      count = _.trim(result.message).split('\n').length
+    }
+
     this.internalFs.cleanPreviousRootEntry()
-    await execAsync('git', containerPath, ['add', '-A'])
-    await execAsync('git', containerPath, ['commit', '-m', 'another-commit'])
+
+    if (!remoteUrl) {
+      if (options.info) {
+        return `       
+Current branch: ${chalk.bold(branch)}
+Number of changed files: ${chalk.bold(count)}
+`
+      } else if (options.push) {
+        await execAsync('git', containerPath, ['add', '-A'])
+        return (await execAsync('git', containerPath, ['commit', '-m', options.message || 'another-commit'])).message
+      } else {
+        throw new Error('Wrong parameters')
+      }
+    }
 
     result = await execAsync('git', containerPath, ['diff', `origin/${branch}`, '--name-only'])
-    let count = 0
+    count = 0
     if (_.trim(result.message)) {
       count = _.trim(result.message).split('\n').length
     }
@@ -94,8 +157,10 @@ Number of changed files: ${chalk.bold(count)}`
     }
 
     if (options.pull || options.push) {
-      return execSync(`cd ${containerPath} && git ${options.pull ? 'pull' : 'push'} origin ${branch}`).toString()
-    }
+      await execAsync('git', containerPath, ['add', '-A'])
+      return `${(await execAsync('git', containerPath, ['commit', '-m', options.message || 'another-commit'])).message}
+${execSync(`cd ${containerPath} && git ${options.pull ? 'pull' : 'push'} origin ${branch}`).toString()}
+`   }
 
     throw new Error('Wrong parameters')
   }


### PR DESCRIPTION
Fix an issue in @secrez/migrate losing old versions during the migration of the database from version 2 to version 3.
Adds more options to Git (`--init`, `--remote-url`, and `--main-branch`) and allow managing local-only repos.