### PR TITLE
Ready for 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__1.0.0__
+* Requires `@secrez/utils@1.0.1` which fixes a yaml parsing error with ETH-like addresses
+
 __1.0.0-beta.3__
 * Rm allows to delete specific versions of a file
 

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -451,6 +451,9 @@ Secrez does not want to compete with password managers. So, don't expect in the 
 
 ## History
 
+__1.0.0__
+* Requires `@secrez/utils@1.0.1` which fixes a yaml parsing error with ETH-like addresses
+
 __1.0.0-beta.3__
 * Rm allows to delete specific versions of a file
 

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",
@@ -19,7 +19,7 @@
     "@secrez/crypto": "workspace:~1.0.0",
     "@secrez/fs": "workspace:~1.0.1",
     "@secrez/hub": "workspace:~0.2.1",
-    "@secrez/utils": "workspace:~1.0.0",
+    "@secrez/utils": "workspace:~1.0.1",
     "case": "^1.6.3",
     "chalk": "^3.0.0",
     "clipboardy": "^2.3.0",

--- a/packages/secrez/src/commands/Cat.js
+++ b/packages/secrez/src/commands/Cat.js
@@ -77,9 +77,9 @@ class Cat extends require('../Command') {
     let tsHash = Node.hashVersion(ts)
     ts = Crypto.fromTsToDate(ts)
     let date = ts[0].split('Z')[0].split('T')
-    let ret = `${tsHash}  ${date[0]}  ${date[1].substring(0, 12)}${ts[1]}`
+    let ret = `-- ${chalk.bold(tsHash)} -- ${date[0]} ${date[1].substring(0, 12)}${ts[1]}`
     if (name) {
-      ret += chalk.grey(' (' + name + ')')
+      ret += ' (' + name + ')'
     }
 
     return ret
@@ -124,7 +124,7 @@ class Cat extends require('../Command') {
               if (fields[field]) {
                 details.content = format(field)
               } else {
-                details.content = chalk.yellow('-- empty field --')
+                details.content = chalk.yellow('-- empty field')
               }
             } else {
               let content = []
@@ -186,16 +186,16 @@ class Cat extends require('../Command') {
         for (let d of data) {
           let {content, ts, type, name} = d
           if (extra) {
-            this.Logger.green(`${this.formatTs(ts, fn === name ? undefined : name)}`)
+            this.Logger.yellow(`${this.formatTs(ts, fn === name ? undefined : name)}`)
           }
           if (type === config.types.TEXT) {
             if (_.trim(content)) {
               this.Logger.reset(_.trim(content))
             } else {
-              this.Logger.yellow('-- this version is empty --')
+              this.Logger.yellow('-- this version is empty')
             }
           } else {
-            this.Logger.yellow('-- this is a binary file --')
+            this.Logger.yellow('-- this is a binary file')
           }
         }
         if (options.notFound && options.notFound.length) {

--- a/packages/secrez/test/commands/Cat.test.js
+++ b/packages/secrez/test/commands/Cat.test.js
@@ -102,7 +102,7 @@ describe('#Cat', function () {
       C.cat.formatTs(versions[1]) + ' (file1)',
       'Password 2',
       C.cat.formatTs(versions[2]) + ' (file1)',
-      '-- this version is empty --'
+      '-- this version is empty'
     ])
   })
 
@@ -142,7 +142,7 @@ describe('#Cat', function () {
     inspect = stdout.inspect()
     await C.cat.exec({path: '/file1.tar.gz'})
     inspect.restore()
-    assertConsole(inspect, ['-- this is a binary file --'])
+    assertConsole(inspect, ['-- this is a binary file'])
 
   })
 
@@ -185,7 +185,7 @@ describe('#Cat', function () {
     output = inspect.output.map(e => decolorize(e))
 
     assert.equal(output[1],  'expose: 6379')
-    assert.equal(output[3],  '-- empty field --')
+    assert.equal(output[3],  '-- empty field')
     assert.equal(output[5],  'expose: 6378')
 
     inspect = stdout.inspect()

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -5,17 +5,25 @@ Secrez is the secrets manager for the cryptocurrencies era.
 This is a utils library used by other packages in the @secrez suite.
 
 
+## History
+
+__1.0.1__
+* adds a workaound to avoid converting ETH addresses to floats
+
+__1.0.0__
+* uses @secrez/core 1.0.0
+
 ## Test coverage
 
 ```
-  37 passing (188ms)
+  38 passing (178ms)
 
 -------------|---------|----------|---------|---------|-------------------
 File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 -------------|---------|----------|---------|---------|-------------------
-All files    |   94.38 |    84.52 |   86.84 |   94.22 |                   
+All files    |   94.44 |    84.88 |   86.84 |   94.29 |                   
  UglyDate.js |     100 |    96.67 |     100 |     100 | 61                
- index.js    |   92.19 |    77.78 |   85.71 |   91.87 | 233-255           
+ index.js    |   92.31 |    78.57 |   85.71 |      92 | 237-259           
 -------------|---------|----------|---------|---------|-------------------
 ```
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secrez/utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -15,6 +15,10 @@ const UglyDate = require('./UglyDate')
 const utils = {
 
   yamlParse(str) {
+    // workaround to avoid parsing ETH addresses
+    if (/: 0x[a-fA-F0-9]{40}/.test(str)) {
+      str = str.replace(/: (0x[a-fA-F0-9]{40})/g, ": '$1'")
+    }
     try {
       return YAML.parse(str)
     } catch (e) {

--- a/packages/utils/test/index.test.js
+++ b/packages/utils/test/index.test.js
@@ -415,6 +415,15 @@ describe('#utils from core', function () {
       }
     })
 
+    it('should not treat an ETH address as a number', async function () {
+      let src = `user: joe
+address: 0x0C192bE3C518edE035ec2F1449b77feeC1C6D92f
+`
+      let parsed = utils.yamlParse(src)
+      assert.equal(parsed.address.toString(), '0x0C192bE3C518edE035ec2F1449b77feeC1C6D92f')
+
+    })
+
   })
 
   describe('yamlStringify', async function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
       '@secrez/fs': workspace:~1.0.1
       '@secrez/hub': workspace:~0.2.1
       '@secrez/test-helpers': workspace:~1.0.1
-      '@secrez/utils': workspace:~1.0.0
+      '@secrez/utils': workspace:~1.0.1
       case: ^1.6.3
       chai: ^4.2.0
       chalk: ^3.0.0


### PR DESCRIPTION
Passing from beta to final version.
Adding minor fix to avoid that YAML parser converts ETH-like addresses to float numbers.
Making more clear the versioning when using `cat -a ...`.