### PR TITLE
Changes to publish

### DIFF
--- a/bin/patch-versions.js
+++ b/bin/patch-versions.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const {execSync} = require('child_process')
 
 let packages = {}
-execSync('git diff master --name-only').toString().split('\n').map(e => {
+execSync('git diff main --name-only').toString().split('\n').map(e => {
   let m = e.split('/')
   if (m[0] === 'packages' && (m[2] === 'src' || m[2] === 'package.json')) {
     packages[m[1]] = true

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -19,7 +19,7 @@ function checkIfMustBePublished(dir) {
     console.debug(`
 MUST PUBLISH ${pkg}${dir} v${version} with
 
-(cd packages/$dir && npm publish)
+(cd packages/${dir} && npm publish)
 `)
 
 

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -16,7 +16,15 @@ function checkIfMustBePublished(dir) {
   const version = require(`../packages/${dir}/package.json`).version
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {
-    console.debug(`MUST PUBLISH ${pkg}${dir} v${version}`)
+    console.debug(`
+MUST PUBLISH ${pkg}${dir} v${version} with
+
+(cd packages/$dir && npm publish)
+`)
+
+
+
+
     // console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
     changes = true
   }

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -21,10 +21,6 @@ MUST PUBLISH ${pkg}${dir} v${version} with
 
 (cd packages/${dir} && pnpm publish)
 `)
-
-
-
-
     // console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
     changes = true
   }

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -19,7 +19,7 @@ function checkIfMustBePublished(dir) {
     console.debug(`
 MUST PUBLISH ${pkg}${dir} v${version} with
 
-(cd packages/${dir} && npm publish)
+(cd packages/${dir} && pnpm publish)
 `)
 
 

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -17,7 +17,7 @@ function checkAndPublish(dir) {
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {
     console.debug(`Publishing  ${pkg}${dir} v${version}`)
-    console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
+    // console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
     changes = true
   }
 }

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -10,29 +10,29 @@ if (gitDiff.length > 0 && gitDiff[0]) {
   process.exit(1)
 }
 
-function checkAndPublish(dir) {
+function checkIfMustBePublished(dir) {
   const pkg = dir === 'secrez' ? '' : '@secrez/'
   console.debug(`Checking  ${pkg}${dir}`)
   const version = require(`../packages/${dir}/package.json`).version
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {
-    console.debug(`Publishing  ${pkg}${dir} v${version}`)
-    console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
+    console.debug(`MUST PUBLISH ${pkg}${dir} v${version}`)
+    // console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
     changes = true
   }
 }
 
-checkAndPublish('utils', '@secrez')
-checkAndPublish('test-helpers', '@secrez')
-checkAndPublish('crypto', '@secrez')
-checkAndPublish('core', '@secrez')
-checkAndPublish('courier', '@secrez')
-checkAndPublish('fs', '@secrez')
-checkAndPublish('hub', '@secrez')
-checkAndPublish('tls', '@secrez')
-checkAndPublish('tunnel', '@secrez')
-checkAndPublish('migrate', '@secrez')
-checkAndPublish('secrez')
+checkIfMustBePublished('utils', '@secrez')
+checkIfMustBePublished('test-helpers', '@secrez')
+checkIfMustBePublished('crypto', '@secrez')
+checkIfMustBePublished('core', '@secrez')
+checkIfMustBePublished('courier', '@secrez')
+checkIfMustBePublished('fs', '@secrez')
+checkIfMustBePublished('hub', '@secrez')
+checkIfMustBePublished('tls', '@secrez')
+checkIfMustBePublished('tunnel', '@secrez')
+checkIfMustBePublished('migrate', '@secrez')
+checkIfMustBePublished('secrez')
 
 if (!changes) {
   console.debug('No upgrade needed.')

--- a/bin/publish-changed-packages.js
+++ b/bin/publish-changed-packages.js
@@ -17,7 +17,7 @@ function checkAndPublish(dir) {
   const currVersion = execSync(`npm view ${pkg}${dir} | grep latest`).toString().split('\n')[0].split(' ')[1]
   if (version !== currVersion) {
     console.debug(`Publishing  ${pkg}${dir} v${version}`)
-    // console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
+    console.debug(execSync(`cd packages/${dir} && pnpm publish ${/beta/.test(version) ? '--tag beta' : ''}`) .toString())
     changes = true
   }
 }

--- a/packages/secrez/.npmignore
+++ b/packages/secrez/.npmignore
@@ -5,3 +5,4 @@ tmp
 .scratch
 .idea
 report20*
+_sullof

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",


### PR DESCRIPTION
Instead of publishing the modified packages, it shows a list of the packages to be published with the command to execute.
This was necessary because of issues when npm requires the OTP.