### PR TITLE
Adding all content when using cryptoEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ Secrez is not intended to compete with password managers, so do not expect it to
 
 ## History
 
+**2.1.6**
+
+- export and encrypt, with option `--crypto-env`, the entire content of an item
+
 **2.1.5**
 
 - duplicate files using `touch <newfile> --from <file>` to copy the file from the source to the destination

--- a/packages/secrez/README.md
+++ b/packages/secrez/README.md
@@ -369,6 +369,10 @@ Secrez is not intended to compete with password managers, so do not expect it to
 
 ## History
 
+**2.1.6**
+
+- export and encrypt, with option `--crypto-env`, the entire content of an item
+
 **2.1.5**
 
 - duplicate files using `touch <newfile> --from <file>` to copy the file from the source to the destination

--- a/packages/secrez/package.json
+++ b/packages/secrez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secrez",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev bin/secrez.js -c `pwd`/tmp/secrez-dev -i 1e3 -l `pwd`/tmp",


### PR DESCRIPTION
The previous version of `export --crypto-env` was built for private keys. The new feature here, allow to encrypt the entire content if no private_key field is found.